### PR TITLE
Update gosura auths

### DIFF
--- a/src/gosura/core.clj
+++ b/src/gosura/core.clj
@@ -64,13 +64,6 @@
     (catch Exception e
       (f/fail (format "Resolver matching failed because of %s" (ex-message e))))))
 
-(defn extract-auth-map
-  [auth]
-  (when (coll? auth)
-    (let [[_auth-fn auth-map] auth]
-      auth-map)))
-
-
 (defn generate-one
   "GraphQL relay spec에 맞는 기본적인 resolver들을 자동 생성한다.
    제공하고 있는 resolvers의 종류는 아래와 같다.
@@ -115,15 +108,10 @@
           (intern target-ns (symbol resolver) (defmethod relay/node-resolver node-type [this ctx _args _parent]
                                                 (f/attempt-all
                                                  [{:keys [auth]} settings
-                                                  auth-map (extract-auth-map auth)
-                                                  auth-result (if-let [role (auth/process-auth-fn auth ctx)]
-                                                                (if (boolean? role)
-                                                                  role
-                                                                  {(role auth-map) (get-in ctx [:identity :id])})
-                                                                (f/fail "Unauthorized"))
-                                                  filter-options (cond-> {:id (or (:db-id this)
-                                                                                  (:id this))}
-                                                                   (map? auth-map) (merge auth-result))
+                                                  auth-filter-opts (auth/auth-filter-opts auth ctx)
+                                                  filter-options (merge {:id (or (:db-id this)
+                                                                                 (:id this))}
+                                                                        auth-filter-opts)
                                                   origin-content (table-fetcher (get ctx db-key) filter-options {})
                                                   _ (when (empty? origin-content)
                                                       (f/fail "NotExistData"))
@@ -142,19 +130,13 @@
                                                                  :or   {kebab-case?        true
                                                                         return-camel-case? true}} settings
                                                                 {:keys [args parent]} (->kebab-case kebab-case? args parent)
-                                                                auth-map (extract-auth-map auth)
-                                                                auth-result (if-let [role (auth/process-auth-fn auth ctx)]
-                                                                              (if (boolean? role)
-                                                                                role
-                                                                                {(role auth-map) (get-in ctx [:identity :id])})
-                                                                              (f/fail "Unauthorized"))
+                                                                auth-filter-opts (auth/auth-filter-opts auth ctx)
                                                                 required-keys-in-parent (remove nil? [fk-in-parent pk-list-name-in-parent])
                                                                 required-keys (s/difference (set required-keys-in-parent) (set (keys parent)))
                                                                 _ (when (seq required-keys)
                                                                     (f/fail (format "%s keys are needed in parent" required-keys)))
                                                                 resolver-fn (match-resolve-fn resolver)
-                                                                added-params (cond-> params
-                                                                               (map? auth-map) (assoc :additional-filter-opts auth-result))]
+                                                                added-params (merge params {:additional-filter-opts auth-filter-opts})]
                                                                (cond-> (resolver-fn ctx args parent added-params)
                                                                  return-camel-case? (util/update-resolver-result util/transform-keys->camelCaseKeyword))
                                                                (f/when-failed [e]

--- a/src/test/gosura/auth_test.clj
+++ b/src/test/gosura/auth_test.clj
@@ -1,0 +1,89 @@
+(ns test.gosura.auth-test
+  (:require [clojure.test :refer [deftest is run-tests testing]]
+            [failjure.core :as f]
+            [gosura.auth :as gosura-auth]))
+
+(deftest extract-auth-map-test
+  (testing "auth의 시그니처가 fn 일 때, 인증에 대한 mapping 결과 컬럼을 잘 반환한다"
+    (let [auth            identity
+          result          (gosura-auth/extract-auth-map auth)
+          expected-result nil]
+      (is (= result expected-result))))
+  (testing "auth의 시그니처가 (fn keyword) 일 때, 인증에 대한 mapping 결과 컬럼을 잘 반환한다"
+    (let [auth            [identity :user-id]
+          result          (gosura-auth/extract-auth-map auth)
+          expected-result :user-id]
+      (is (= result expected-result))))
+  (testing "auth의 시그니처가 (fn map) 일 때, 인증에 대한 mapping 결과 컬럼을 잘 반환한다"
+    (let [auth            [identity {:admin :user-id}]
+          result          (gosura-auth/extract-auth-map auth)
+          expected-result {:admin :user-id}]
+      (is (= result expected-result)))))
+
+(deftest auth-filter-opts-test
+  (let [auth0 (fn [ctx]
+                (boolean (get-in ctx [:identity :id])))
+        auth1 (fn [ctx role]
+                (let [user-role (keyword (get-in ctx [:identity :role]))]
+                  (if (set? user-role)
+                    (role user-role)
+                    (when (role user-role) ; map
+                      user-role))))
+        unauthorized (f/fail "Unauthorized")]
+    (testing "auth가 없을 때, 아무일도 일어나지 않는다"
+      (let [auth            nil
+            ctx             {:identity {:id "1"}}
+            result          (gosura-auth/auth-filter-opts auth ctx)
+            expected-result nil]
+        (is (= result expected-result))))
+    (testing "auth의 시그니처가 fn 일 때, auth0 인증을 통과한 경우 추가 필터는 없다"
+      (let [auth            auth0
+            ctx             {:identity {:id "1"}}
+            result          (gosura-auth/auth-filter-opts auth ctx)
+            expected-result nil]
+        (is (= result expected-result))))
+    (testing "auth의 시그니처가 fn 일 때, auth0 인증에 실패하면 Unauthorized 메시지를 반환한다."
+      (let [auth            auth0
+            ctx             {}
+            result          (gosura-auth/auth-filter-opts auth ctx)]
+        (is (= result unauthorized))))
+    (testing "auth의 시그니처가 (fn keyword) 일 때, auth0 인증을 통과한 후 추가 필터는 {keyword : auth-id}를 잘 반환한다"
+      (let [auth            [auth0 :user-id]
+            ctx             {:identity {:id "1"}}
+            result          (gosura-auth/auth-filter-opts auth ctx)
+            expected-result {:user-id "1"}]
+        (is (= result expected-result))))
+    (testing "auth의 시그니처가 (fn keyword) 일 때, auth0 인증에 실패하면 Unauthorized 메시지를 반환한다."
+      (let [auth            [auth0 :user-id]
+            ctx             {}
+            result          (gosura-auth/auth-filter-opts auth ctx)]
+        (is (= result unauthorized))))
+    (testing "auth의 시그니처가 (fn set) 일 때, auth1 인증을 통과한 후 추가 필터는 없다"
+      (let [auth            [auth1 #{:admin}]
+            ctx             {:identity {:id   "1"
+                                        :role "admin"}}
+            result          (gosura-auth/auth-filter-opts auth ctx)
+            expected-result nil]
+        (is (= result expected-result))))
+    (testing "auth의 시그니처가 (fn set) 일 때, auth1 인증에 실패하면 Unauthorized 메세지를 반환한다"
+      (let [auth            [auth1 #{:admin}]
+            ctx             {:identity {:id   "1"
+                                        :role "buyer"}}
+            result          (gosura-auth/auth-filter-opts auth ctx)]
+        (is (= result unauthorized))))
+    (testing "auth의 시그니처가 (fn map) 일 때, auth1 인증을 통과한 후 추가 필터는 {auth-map에 해당하는 value : auth-id}를 잘 반환한다"
+      (let [auth            [auth1 {:admin :user-id}]
+            ctx             {:identity {:id   "1"
+                                        :role "admin"}}
+            result          (gosura-auth/auth-filter-opts auth ctx)
+            expected-result {:user-id "1"}]
+        (is (= result expected-result))))
+    (testing "auth의 시그니처가 (fn map) 일 때, auth1 Unauthorized 메세지를 반환한다"
+      (let [auth            [auth1 {:admin :user-id}]
+            ctx             {:identity {:id   "1"
+                                        :role "buyer"}}
+            result          (gosura-auth/auth-filter-opts auth ctx)]
+        (is (= result unauthorized))))))
+
+(comment
+  (run-tests))


### PR DESCRIPTION
- 신선하이 사용을 위해 만들었던 auth 추가 필터를 다른 인증 방식인 팜모닝에 맞추어서 사용할 수 있도록 코드를 수정하였습니다.
- 변경사항은 아래와 같습니다.

기존에는 롤까지 검증하고 있던 아래 케이스에서만
```clojure
{:settings {:auth [auth-fn {:admin :user-id}]}}
```
auth-id 필터를 잘 적용하였는데



해당 PR에 추가된 내용은 단순 인증만 하는 케이스에서
```clojure
{:settings {:auth [auth-fn :user-id] }
```
인허가 통과 후 요청자에 대한 필터 기능을 추가하였습니다.