### PR TITLE
better conditional check for server-error fn

### DIFF
--- a/src/gosura/helpers/response.clj
+++ b/src/gosura/helpers/response.clj
@@ -30,7 +30,7 @@
   ([profile error]
    (server-error profile error nil))
   ([profile error message]
-   (let [message (if (= "prod" (string/lower-case profile))
+   (let [message (if (and profile (= "prod" (string/lower-case profile)))
                    "서버의 알 수 없는 에러"
                    (or message (ex-message error)))]
      (util/send-sentry-server-event {:message   message


### PR DESCRIPTION
- profile이 없을 때 lower-case할 때 에러가 발생해서 profile이 존재할 때의 조건을 추가해줬습니다.