### PR TITLE
take generated-key out

### DIFF
--- a/src/gosura/helpers/resolver.clj
+++ b/src/gosura/helpers/resolver.clj
@@ -357,9 +357,7 @@
                          pre-process-arguments)
                      additional-filter-opts)]
     (try
-      (if-let [id (->> input
-                       (mutation-fn db)
-                       :generated-key)] ; 한계) auto-gen key가 있는 경우에만 사용 가능
+      (if-let [id (mutation-fn db input)]
         (response/->mutation-response (-> (table-fetcher db {:id id} {})
                                           first
                                           (relay/build-node node-type post-process-row))


### PR DESCRIPTION
- resolve-create-one 할 때 :generated-key를 resolver내에서 처리하도록 하였는데 그러다보니 한계(auth-gen 필수)가 있었음
- mutation-fn에게 id를 반환하는 역할을 넘기도록 함