### PR TITLE
단어 resolver-fn 을 docstring 과 함수이름에 좀 더 사용합니다

### DIFF
--- a/src/gosura/core.clj
+++ b/src/gosura/core.clj
@@ -1,10 +1,11 @@
 (ns gosura.core
-  "GraphQL relay spec에 맞는 기본적인 resolver들을 자동 생성하려합니다.
-   이에 필요한 schema, generator 등을 정의합니다
-   edn 파일로 정의하지 않으면 자동생성되지 않으니 강제 사항은 아닙니다
-   필요한 resolver만 자동 생성하고 custom하게 작성해야하는 경우는 따로 작성하면 됩니다
+  "relay.dev spec 의 Connection, Node 를 구현하는
+   lacinia schema, resolver-fn 을 생성합니다.
 
-   주의) namespace를 임의로 지정하기 보다는 ns를 정의를 하고 해당 네임스페이스를 사용하기시 바랍니다(ns 선언 외 빈 파일)"
+   gosura resolver-config edn 파일을 정의하면 생성합니다.
+   gosura 에서 생성하는 resolver-fn 이 부적합 할 때는 따로 작성하는 것이 더 적절할 수 있습니다.
+
+   주의) resolver-config edn 에 사용하는 ns 는 (ns 선언만 있는 빈 파일을 만들고) 그 네임스페이스를 사용하세요."
   (:require [camel-snake-kebab.core :as csk]
             [clojure.set :as s]
             [clojure.tools.logging :as log]
@@ -70,14 +71,11 @@
       (f/fail (format "Can't find resolver-fn because of %s" (ex-message e))))))
 
 (defn generate-one
-  "GraphQL relay spec에 맞는 기본적인 resolver들을 자동 생성한다.
-   제공하고 있는 resolvers의 종류는 아래와 같다.
-   - resolve-connection: GraphQL relay spec에서 connection object를 조회할 때
-   - resolve-by-fk: fk로 조회한 값
-   - resolve-connection-by-xxx: xxx는 보통 fk로, xxx에 따른 connection object를 조회할 때 사용한다
+  "gosura resolver-config edn 을 받아
+   :target-ns 에 resolver-fn 을 생성(intern)합니다.
 
-   m: 설정값의 hash-map
-   예시)
+   gosura `resolver-config` edn 예)
+   ```
    {:target-ns         ns
     :resolvers         {:resolve-connection               {:node-type             node-type
                                                            :db-key                db-key
@@ -93,6 +91,7 @@
                                                            :node-type         node-type
                                                            :superfetcher      superfetcher/->FetchByExampleId
                                                            :post-process-row  post-process-row}}}
+   ```
    "
   [resolver-config]
   (when-not (m/validate schema/resolvers-map-schema resolver-config)

--- a/src/gosura/helpers/resolver.clj
+++ b/src/gosura/helpers/resolver.clj
@@ -1,4 +1,15 @@
 (ns gosura.helpers.resolver
+  "resolver-fn 의 모음.
+
+  resolve-connection
+  resolve-connection-by-fk
+  resolve-connection-by-pk-list
+  resolve-by-fk
+  resolve-by-parent-pk
+  ...
+
+  를 resolver-fn 이라 부르자, 약속해봅니다.
+  "
   (:require [camel-snake-kebab.core :as csk]
             [clojure.string :refer [ends-with?]]
             [com.walmartlabs.lacinia.resolve :refer [resolve-as]]
@@ -67,7 +78,7 @@
      :body body}))
 
 (defmacro defresolver
-  "GraphQL resolver 함수를 만듭니다.
+  "lacinia 용 resolver 함수를 만듭니다.
 
   입력
   name - 함수 이름

--- a/test/gosura/core_test.clj
+++ b/test/gosura/core_test.clj
@@ -2,7 +2,8 @@
   (:require [clojure.set :as set]
             [clojure.test :refer [deftest is testing]]
             [gosura.core :as gosura]
-            [gosura.helpers.resolver :as gosura-resolver]))
+            [gosura.helpers.resolver :as gosura-resolver]
+            [failjure.core :as f]))
 
 (def normal-data (-> "test/resources/gosura/sample_resolver_configs.edn"
                      slurp
@@ -21,20 +22,18 @@
   #_(testing "settings in return-camel-case? 가 잘 동작한다")
   #_(testing "settings in required-keys-in-parent 가 잘 동작한다"))
 
-(deftest match-resolve-fn-test
-  (testing "gosura resolver에 필요한 match-resolve-fn은"
-    (testing "resolve-connection을 잘 매칭한다"
-      (is (= (gosura/match-resolve-fn :resolve-connection) gosura-resolver/resolve-connection)))
-    (testing "resolve-by-fk를 잘 매칭한다"
-      (is (= (gosura/match-resolve-fn :resolve-by-fk) gosura-resolver/resolve-by-fk)))
-    (testing "resolve-connection-by-pk-list를 잘 매칭한다"
-      (is (= (gosura/match-resolve-fn :resolve-connection-by-pk-list) gosura-resolver/resolve-connection-by-pk-list)))
-    (testing "resolve-connection-by-some-id를 잘 매칭한다"
-      (is (= (gosura/match-resolve-fn :resolve-connection-by-sample-id) gosura-resolver/resolve-connection-by-fk)))
-    (testing "매칭할게 없다면 에러 메시지를 잘 뱉어낸다"
-      (let [bad-resolver :bad-resolver]
-        (is (= (format "Resolver matching failed because of No matching clause: %s" (name bad-resolver))
-               (:message (gosura/match-resolve-fn bad-resolver))))))))
+(deftest find-resolver-fn-test
+  (testing "find-resolver-fn 가"
+    (testing "resolve-connection 을 잘 찾는다"
+      (is (= (gosura/find-resolver-fn :resolve-connection) gosura-resolver/resolve-connection)))
+    (testing "resolve-by-fk 를 잘 찾는다"
+      (is (= (gosura/find-resolver-fn :resolve-by-fk) gosura-resolver/resolve-by-fk)))
+    (testing "resolve-connection-by-pk-list 를 잘 찾는다"
+      (is (= (gosura/find-resolver-fn :resolve-connection-by-pk-list) gosura-resolver/resolve-connection-by-pk-list)))
+    (testing "resolve-connection-by-some-id 를 잘 찾는다"
+      (is (= (gosura/find-resolver-fn :resolve-connection-by-sample-id) gosura-resolver/resolve-connection-by-fk)))
+    (testing "찾을 수 없다면 failed? 가 true 이다"
+      (is (f/failed? (gosura/find-resolver-fn :resolve-un-exist))))))
 
 (deftest gosura-resolver-generate-all-test
   "gosura resolver의 generate-all은"


### PR DESCRIPTION
- s/match-resolve-fn/find-resolver-fn
- resolve fn 과 resolver fn 을 섞어 사용하니, 후자로 모으려는 시도의 일부 입니다. 
- 인자 이름으로 resolver 를 받는데, clojure `keyword` 라는 사실을 강조하려고 resolver-key 로 바꿉니다.
- helpers.resolver ns 에 있는 var 를 resolver-fn 으로 부르자, docstring 에서 강조합니다. 
- 단어 `resolver-config` 를 docstring 에서 좀 더 사용합니다. 