### PR TITLE
superfetcher-v2 에서 `batch-args` 내려줄 때 id 키를 id-in-parent로 rename

### DIFF
--- a/src/gosura/helpers/superlifter.clj
+++ b/src/gosura/helpers/superlifter.clj
@@ -1,6 +1,7 @@
 (ns gosura.helpers.superlifter
   (:require [com.walmartlabs.lacinia.resolve :as resolve]
-            [superlifter.api :as api]))
+            [superlifter.api :as api]
+            [clojure.set :as s]))
 
 ;; Superlifter.lacinia가 Pedestal 의존성이 있기 때문에, ns를 불러올 수 없음.
 ;; https://github.com/oliyh/superlifter/blob/master/src/superlifter/lacinia.clj
@@ -83,7 +84,9 @@
                  (map :id)
                  (map str))
         base-filter-options (->> arguments-list first :filter-options)
-        batch-args (map #(dissoc % :page-options :filter-options) arguments-list)
+        batch-args (->> arguments-list
+                        (map #(dissoc % :page-options :filter-options))
+                        (map #(s/rename-keys % {:id id-in-parent})))
         filter-options (merge base-filter-options
                               {:batch-args batch-args})
         base-page-options (->> arguments-list first :page-options)

--- a/test/gosura/helpers/superlifter_test.clj
+++ b/test/gosura/helpers/superlifter_test.clj
@@ -44,7 +44,32 @@
                            :cursor-id nil
                            :cursor-ordered-value nil
                            :page-size 10}
-        result '([{:id "1204" :title "title1"}] [{:id "1123" :title "title3"}] [{:id "370" :title "title2"}])))))
+        result '([{:id "1204" :title "title1"}] [{:id "1123" :title "title3"}] [{:id "370" :title "title2"}]))))
+        
+        (testing "superlifter에 id-in-parent 값이 :id 가 아닐 때 잘 변환합니다."
+          (let [filter-option-args (atom {})
+                page-option-args (atom {})
+                args {:db-key :db
+                      :table-fetcher (fn [_db filter-options page-options]
+                                       (reset! filter-option-args filter-options)
+                                       (reset! page-option-args page-options)
+                                       [{:id-2 "1204" :title "title1"}
+                                        {:id-2 "370" :title "title2"}
+                                        {:id-2 "1123" :title "title3"}])
+                      :id-in-parent :id-2}
+                result (superfetch-v2 superlifter-requests {} args)]
+            (are [expected target] (= expected target)
+              @filter-option-args {:test-filter "filter"
+                                   :batch-args [{:country-code "JP" :id-2 "1204"}
+                                                {:country-code "JP" :id-2 "1123"}
+                                                {:country-code "JP" :id-2 "370"}]}
+              @page-option-args {:order-by :id
+                                 :order-direction :asc
+                                 :page-direction :forward
+                                 :cursor-id nil
+                                 :cursor-ordered-value nil
+                                 :page-size 10}
+              result '([{:id-2 "1204" :title "title1"}] [{:id-2 "1123" :title "title3"}] [{:id-2 "370" :title "title2"}])))))
 
 (comment
   (run-tests))


### PR DESCRIPTION
## 문제
* `gosura/superfetcher-v2` 의 사용처 중 `id-in-parent` 의 값이 `id` 가 아닌 경우 제대로 조회하지 못하는 버그가 있습니다.

## 해결
* `gosura/superfetcher-v2` 에서 `batch-args` 를 내려줄 때 `id`값을 클라이언트에서 명시한 `id-in-parent` 로 변환하여 내려줍니다.
