### PR TITLE
cursor-filter-pred에서 order-by 컬럼에 대해 table-name-alias를 붙일 수 있도록 처리

### DIFF
--- a/src/gosura/helpers/db.clj
+++ b/src/gosura/helpers/db.clj
@@ -33,7 +33,8 @@
    (when (and order-by cursor-id)
      (let [operator ({:asc  :>=
                       :desc :<=} order-direction :>=)
-           id       (col-with-table-name table-name-alias :id)]
+           id       (col-with-table-name table-name-alias :id)
+           order-by (col-with-table-name table-name-alias order-by)]
        (if (= order-by id)
          [operator id cursor-id]
          [operator (sql-helper/columns order-by id) [cursor-ordered-value cursor-id]]))))


### PR DESCRIPTION
 https://sentry.io/organizations/greenlabs/issues/3513999784/?project=5868186&referrer=slack
위 에러를 해결하기 위한 PR입니다.
fetcher가 여러 테이블을 join해서 가져오려 할 때, join 대상 테이블에 같은 이름의 컬럼이 있다면 where절에서 그 컬럼을 일컫을 때 table alias를 붙여줘야 합니다. 따라서 table-name-alias가 지정된 경우, id 컬럼 이외에도 커서의 order-by 필드 컬럼에 대해 테이블 alias를 붙여 줍니다.