### PR TITLE
Use #var tagged literal

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,18 +33,18 @@ This is almost full configs you're able to set.
 {:target-ns             animal.resolve ; a generated resolver's namespace
  :node-type             :animal ; node-type for relay
  :db-key                :db ; db-key to find datasource in a lacinia's context
- :pre-process-arguments animal.core/pre-process-arguments ; fn to process in args
- :post-process-row      animal.core/post-process-row ; fn to process in a result
- :filters               {:country-code animal.core/get-country-code} ; filters for additional filter opts for query
- :resolvers             {:resolve-node       {:table-fetcher animal.db/fetch} ; table fetcher for queries
-                         :resolve-connection {:table-fetcher animal.db/fetch
-                                              :settings      {:auth               animal.core/auth ; set for authentification and authorization.
+ :pre-process-arguments #var animal.core/pre-process-arguments ; fn to process in args
+ :post-process-row      #var animal.core/post-process-row ; fn to process in a result
+ :filters               {:country-code #var animal.core/get-country-code} ; filters for additional filter opts for query
+ :resolvers             {:resolve-node       {:table-fetcher #var animal.db/fetch} ; table fetcher for queries
+                         :resolve-connection {:table-fetcher #var animal.db/fetch
+                                              :settings      {:auth               #var animal.core/auth ; set for authentification and authorization.
                                                               :kebab-case?        true ; opts ; transform args into kebeb-case. A default is true.
                                                               :return-camel-case? true}} ; opts ; transform results into camelCase. A default value is true.
-                         :resolve-by-fk      {:superfetcher animal.superfetcher/->Fetch ; superfetcher for superlifter
+                         :resolve-by-fk      {:superfetcher #var animal.superfetcher/->Fetch ; superfetcher for superlifter
                                               :fk-in-parent :user-type-id}
-                         :resolve-create-one {:table-fetcher animal.db/fetch
-                                              :mutation-fn   animal.core/create-one 
+                         :resolve-create-one {:table-fetcher #var animal.db/fetch
+                                              :mutation-fn   #var animal.core/create-one 
                                               :mutation-tag  AnimalPayload}}}
 ```
 
@@ -99,15 +99,15 @@ Here's things.
                      :filter-key    :ids})
 ```
 
-`generate-all` must be executed before lacinia compiles schema because `generate-all` has to make all the resolvers in edn where we define.
+`generate-all` must be executed before lacinia compiles schema because `generate-all` has to make all the resolvers in edn where we define. In order to use a tagged literal `#var`, make sure you need to use `gosura.edn/read-config`.
 ```clojure
-(require '[gosura.core :as gosura])
+(require '[gosura.core :as gosura]
+          [gosura.edn])
 
 (defn- read-in-resource [path]
   (-> path
       clojure.java.io/resource
-      slurp
-      cloure.edn/read-string))
+      gosura.edn/read-config))
 
 (def gosura-resolvers
   (->> ["resolver/animal.edn"]

--- a/deps.edn
+++ b/deps.edn
@@ -15,7 +15,8 @@
            superlifter/superlifter             {:git/url "https://github.com/green-labs/superlifter.git"
                                                 :sha     "e0df5b36b496c485c75f38052a71b18f02772cc0"}
            metosin/malli                       {:mvn/version "0.8.4"}
-           com.github.seancorfield/next.jdbc   {:mvn/version "1.2.780"}}
+           com.github.seancorfield/next.jdbc   {:mvn/version "1.2.780"}
+           aero/aero                           {:mvn/version "1.1.6"}}
 
  :aliases {:test  {:extra-paths ["test"]
                    :extra-deps  {io.github.cognitect-labs/test-runner {:git/tag "v0.5.0"

--- a/src/gosura/core.clj
+++ b/src/gosura/core.clj
@@ -17,7 +17,8 @@
             [gosura.helpers.resolver :as r]
             [gosura.schema :as schema]
             [gosura.util :as util :refer [transform-keys->camelCaseKeyword
-                                          transform-keys->kebab-case-keyword]]
+                                          transform-keys->kebab-case-keyword
+                                          requiring-var!]]
             [malli.core :as m]
             [malli.error :as me]
             [medley.core :as medley]))
@@ -30,23 +31,28 @@
     {:args   args
      :parent parent}))
 
-(defn- auth-symbol->requiring-var!
+(defn-
+  ^{:deprecated "0.2.8"}
+  auth-symbol->requiring-var!
   [params]
   (cond-> params
-    (symbol? (get-in params [:settings :auth 0])) (update-in [:settings :auth 0] requiring-resolve)
-    (symbol? (get-in params [:settings :auth])) (update-in [:settings :auth] requiring-resolve)))
+    (symbol? (get-in params [:settings :auth 0])) (update-in [:settings :auth 0] requiring-var!)
+    (symbol? (get-in params [:settings :auth])) (update-in [:settings :auth] requiring-var!)))
 
-(defn- symbol->requiring-var!  "params: original params
+(defn-
+  ^{:deprecated "0.2.8"}
+  symbol->requiring-var!
+  "params: original params
    symbol로 들어온 값들 중에 var로 취급되어야하는 것들을 변환한다"
   [params]
   (-> params
       auth-symbol->requiring-var!
-      (medley/update-existing :table-fetcher requiring-resolve)
-      (medley/update-existing :pre-process-arguments requiring-resolve)
-      (medley/update-existing :post-process-row requiring-resolve)
-      (medley/update-existing :superfetcher requiring-resolve)
-      (medley/update-existing :mutation-fn requiring-resolve)
-      (medley/update-existing :fetch-one requiring-resolve)))
+      (medley/update-existing :table-fetcher requiring-var!)
+      (medley/update-existing :pre-process-arguments requiring-var!)
+      (medley/update-existing :post-process-row requiring-var!)
+      (medley/update-existing :superfetcher requiring-var!)
+      (medley/update-existing :mutation-fn requiring-var!)
+      (medley/update-existing :fetch-one requiring-var!)))
 
 (defn find-resolver-fn
   "resolver-key 에 따라 적절한 resolver-fn 함수를 리턴한다.
@@ -105,8 +111,8 @@
     (doseq [[resolver params] resolvers]
       (let [params (merge {:node-type        node-type
                            :db-key           db-key
-                           :post-process-row (if (nil? post-process-row) identity (requiring-resolve post-process-row))
-                           :pre-process-arguments (if (nil? pre-process-arguments) identity (requiring-resolve pre-process-arguments))}
+                           :post-process-row (if (nil? post-process-row) identity (requiring-var! post-process-row))
+                           :pre-process-arguments (if (nil? pre-process-arguments) identity (requiring-var! pre-process-arguments))}
                           (symbol->requiring-var! params))
             {:keys [table-fetcher node-type post-process-row db-key settings fk-in-parent pk-list-name-in-parent]} params]
         (if (= :resolve-node resolver)

--- a/src/gosura/edn.clj
+++ b/src/gosura/edn.clj
@@ -1,0 +1,10 @@
+(ns gosura.edn
+  (:require [aero.core :as aero]))
+
+(defmethod aero/reader 'var
+  [_opts _tag value]
+  (requiring-resolve value))
+
+(defn read-config
+  [path]
+  (aero/read-config path))

--- a/src/gosura/util.clj
+++ b/src/gosura/util.clj
@@ -73,7 +73,7 @@
   "qualified-symbol을 var로 변환합니다"
   [sym|var]
   (cond
-    (symbol? sym|var) (requiring-var! sym|var)
+    (symbol? sym|var) (requiring-resolve sym|var)
     (var? sym|var) sym|var
     :else (prn "something wrong")))
 

--- a/test/gosura/edn_test.clj
+++ b/test/gosura/edn_test.clj
@@ -1,0 +1,13 @@
+(ns gosura.edn-test
+  (:require [clojure.test :refer [deftest is run-tests testing]]
+            [gosura.edn]))
+
+(deftest read-config-test
+  (testing "#var tag가 있을 경우 edn 파일을 읽은 후 symbol을 var로 변환한다."
+    (let [my-config (gosura.edn/read-config "test/resources/gosura/tagged_literal_config.edn")]
+      (is (var? (:fn1 my-config)))
+      (is (symbol? (:fn2 my-config)))
+      (is (= 2 ((:fn3 my-config) 1))))))
+
+(comment
+  (run-tests))

--- a/test/gosura/util_test.clj
+++ b/test/gosura/util_test.clj
@@ -1,0 +1,18 @@
+(ns gosura.util-test
+  (:require [clojure.test :refer [deftest is run-tests testing]]
+            [gosura.edn]
+            [gosura.util :as util]))
+
+(deftest requiring-var!-test
+  (testing "argument에 var가 들어오면 var를 그대로 반환한다"
+    (let [my-config (gosura.edn/read-config "test/resources/gosura/tagged_literal_config.edn")]
+      (is (var? (util/requiring-var! (:fn1 my-config))))))
+  (testing "argument에 symbol이 들어오면 var를 변환한다"
+    (let [my-config (gosura.edn/read-config "test/resources/gosura/tagged_literal_config.edn")]
+      (is (var? (util/requiring-var! (:fn2 my-config))))))
+  (testing "argument에 var도 symbol이 아닌 값이 들어오면 nil을 반환한다"
+    (let [my-config (gosura.edn/read-config "test/resources/gosura/tagged_literal_config.edn")]
+      (is (nil? (util/requiring-var! (:fn4 my-config)))))))
+
+(comment
+  (run-tests))

--- a/test/resources/gosura/tagged_literal_config.edn
+++ b/test/resources/gosura/tagged_literal_config.edn
@@ -1,0 +1,4 @@
+{:fn1 #var clojure.core/identity
+ :fn2 clojure.core/identity
+ :fn3 #var clojure.core/inc}
+

--- a/test/resources/gosura/tagged_literal_config.edn
+++ b/test/resources/gosura/tagged_literal_config.edn
@@ -1,4 +1,4 @@
 {:fn1 #var clojure.core/identity
  :fn2 clojure.core/identity
- :fn3 #var clojure.core/inc}
-
+ :fn3 #var clojure.core/inc
+ :fn4 :keyword}


### PR DESCRIPTION
clojure에서는 edn파일을 읽었을 때 특정 값을 함수로 사용하고 싶을 때 (var 로) qualified-symbol을 사용한 후에 requiring-resolve을 필연적으로 해줘야합니다. `#var` tagged literal을 사용해서 코드가 아닌 edn 파일에서 명시하도록 하였습니다.

클로저 코어팀에서도 이를 표준으로 넣을지 말지 고민하고 있는 것이라고 합니다. 관련 이슈 https://clojure.atlassian.net/browse/CLJ-2165

기존 코드에서는 #var가 붙어있지 않은 경우가 있어서 이를 혼용해서 사용하기 위해서 `requiring-var!`이라는 util함수를 사용해서 하위호환을 고려하였습니다.