### PR TITLE
superfetcher-v2 id-in-parent를 relation-id로 네이밍 변경

### DIFF
--- a/src/gosura/helpers/superlifter.clj
+++ b/src/gosura/helpers/superlifter.clj
@@ -77,7 +77,7 @@
      * env - {:db #object[com.zaxxer.hikari.HikariDataSource] ...}"
   [many
    env
-   {:keys [db-key table-fetcher id-in-parent]}]
+   {:keys [db-key table-fetcher relation-id]}]
   (let [db (get env db-key)
         arguments-list (map :arguments many)
         ids (->> arguments-list
@@ -86,14 +86,14 @@
         base-filter-options (->> arguments-list first :filter-options)
         batch-args (->> arguments-list
                         (map #(dissoc % :page-options :filter-options))
-                        (map #(s/rename-keys % {:id id-in-parent})))
+                        (map #(s/rename-keys % {:id relation-id})))
         filter-options (merge base-filter-options
                               {:batch-args batch-args})
         base-page-options (->> arguments-list first :page-options)
         page-options (dissoc base-page-options :limit)  ; (연오) foolproof: 페치할 때 LIMIT 하면 안 된다. 페치 -> ID별 그룹 -> 그룹별 LIMIT
         id->rows (->> (table-fetcher db filter-options page-options)
-                      (map #(update % id-in-parent str))  ; ids가 str로 입력되므로 맞춤
-                      (group-by id-in-parent))]
+                      (map #(update % relation-id str))  ; ids가 str로 입력되므로 맞춤
+                      (group-by relation-id))]
     (map id->rows ids))) ; rows를 ids 순서대로 배치
 
 (defmacro superfetcher-v2

--- a/test/gosura/helpers/superlifter_test.clj
+++ b/test/gosura/helpers/superlifter_test.clj
@@ -31,7 +31,7 @@
                                  [{:id "1204" :title "title1"}
                                   {:id "370" :title "title2"}
                                   {:id "1123" :title "title3"}])
-                :id-in-parent :id}
+                :relation-id :id}
           result (superfetch-v2 superlifter-requests {} args)]
       (are [expected target] (= expected target)
         @filter-option-args {:test-filter "filter"
@@ -46,7 +46,7 @@
                            :page-size 10}
         result '([{:id "1204" :title "title1"}] [{:id "1123" :title "title3"}] [{:id "370" :title "title2"}]))))
         
-        (testing "superlifter에 id-in-parent 값이 :id 가 아닐 때 잘 변환합니다."
+        (testing "superlifter에 relation-id 값이 :id 가 아닐 때 잘 변환합니다."
           (let [filter-option-args (atom {})
                 page-option-args (atom {})
                 args {:db-key :db
@@ -56,7 +56,7 @@
                                        [{:id-2 "1204" :title "title1"}
                                         {:id-2 "370" :title "title2"}
                                         {:id-2 "1123" :title "title3"}])
-                      :id-in-parent :id-2}
+                      :relation-id :id-2}
                 result (superfetch-v2 superlifter-requests {} args)]
             (are [expected target] (= expected target)
               @filter-option-args {:test-filter "filter"


### PR DESCRIPTION
의미를 명확하게 하기 위하여 `superfetcher-v2`의 `id-in-parent` 인자의 네이밍을 `relation-id`로 변경합니다.

다른 네이밍 제안도 환영입니다!