### PR TITLE
Add experiment resolver2

### DIFF
--- a/src/gosura/core.clj
+++ b/src/gosura/core.clj
@@ -15,6 +15,7 @@
             [gosura.auth :as auth]
             [gosura.helpers.relay :as relay]
             [gosura.helpers.resolver :as r]
+            [gosura.helpers.resolver2 :as r2]
             [gosura.schema :as schema]
             [gosura.util :as util :refer [transform-keys->camelCaseKeyword
                                           transform-keys->kebab-case-keyword
@@ -72,7 +73,11 @@
       #"resolve-update-one" r/resolve-update-one
       #"resolve-delete-one" r/resolve-delete-one
       #"resolve-update-multi" r/resolve-update-multi
-      #"resolve-one" r/resolve-one)
+      #"resolve-one" r/resolve-one
+      
+      ;; resolver2
+      #"connection-by-(.*)" r2/connection-by
+      #"one-by-(.*)" r2/one-by)
     (catch Exception e
       (f/fail (format "Can't find resolver-fn because of %s" (ex-message e))))))
 

--- a/src/gosura/helpers/resolver.clj
+++ b/src/gosura/helpers/resolver.clj
@@ -155,7 +155,7 @@
        decode-global-ids-in-arguments
        decode-global-id-in-arguments))
 
-(defn- nullify-empty-string-arguments
+(defn nullify-empty-string-arguments
   [arguments ks]
   (reduce (fn [arguments k]
             (if (= (get arguments k) "")

--- a/src/gosura/helpers/resolver2.clj
+++ b/src/gosura/helpers/resolver2.clj
@@ -90,7 +90,10 @@
   * config    리졸버 동작 설정
     * :superfetcher: 슈퍼페처
     * :post-process-row: 결과 객체 목록 후처리 함수 (예: identity)
-    * :parent-id: 부모로부터 전달되는 id 정보 예) {:pre-fn relay/decode-global-id->db-id :prop :id} {:prop :user-id}
+    * :parent-id: 부모로부터 전달되는 id 정보 예) {:pre-fn relay/decode-global-id->db-id :prop :id :agg :id} {:prop :user-id :agg :id}
+     * :pre-fn: 전처리
+     * :prop: 부모로부터 전달 받는 키값
+     * :agg: 데이터를 모으는 키값 
   ## 반환
   * 객체 목록
   "
@@ -104,7 +107,7 @@
   (let [arguments (-> arguments
                       common-pre-process-arguments
                       (nullify-empty-string-arguments [:after :before]))
-        {:keys [pre-fn prop]} parent-id
+        {:keys [pre-fn prop agg]} parent-id
         load-id (-> parent
                     (or pre-fn identity)
                     prop)
@@ -116,7 +119,7 @@
         superfetch-arguments (merge additional-filter-opts
                                     {:id           load-id
                                      :page-options page-options
-                                     :prop         prop})
+                                     :agg          agg})
         superfetch-id (hash superfetch-arguments)]
     (with-superlifter (:superlifter context)
       (-> (superlifter-api/enqueue! db-key (superfetcher superfetch-id superfetch-arguments))
@@ -136,7 +139,10 @@
     * :db-key            사용할 DB 이름
     * :superfetcher      슈퍼페처
     * :post-process-row  결과 객체 목록 후처리 함수 (예: identity)
-    * :parent-id: 부모로부터 전달되는 id 정보 예) {:fn relay/decode-global-id->db-id :prop :id} {:prop :user-id}
+    * :parent-id: 부모로부터 전달되는 id 정보 예) {:pre-fn relay/decode-global-id->db-id :prop :id :agg :id} {:prop :user-id :agg :id}
+     * :pre-fn: 전처리
+     * :prop: 부모로부터 전달 받는 키값
+     * :agg: 데이터를 모으는 키값 
   ## 반환
   * 객체 하나
   "
@@ -147,14 +153,14 @@
                                      parent-id
                                      additional-filter-opts]}]
   {:pre [(some? db-key)]}
-  (let [{:keys [pre-fn prop]} parent-id
+  (let [{:keys [pre-fn prop agg]} parent-id
         load-id (-> parent
                     (or pre-fn identity)
                     prop)
         superfetch-arguments (merge additional-filter-opts
                                     {:id           load-id
                                      :page-options nil
-                                     :prop         prop})
+                                     :agg          agg})
         superfetch-id        (hash superfetch-arguments)]
     (with-superlifter (:superlifter context)
       (-> (superlifter-api/enqueue! db-key (superfetcher superfetch-id superfetch-arguments))

--- a/src/gosura/helpers/resolver2.clj
+++ b/src/gosura/helpers/resolver2.clj
@@ -114,7 +114,8 @@
          :as   page-options} (relay/build-page-options arguments)
         superfetch-arguments (merge additional-filter-opts
                                     {:id           load-id
-                                     :page-options page-options})
+                                     :page-options page-options
+                                     :load-id      load-id})
         superfetch-id (hash superfetch-arguments)]
     (with-superlifter (:superlifter context)
       (-> (superlifter-api/enqueue! db-key (superfetcher superfetch-id superfetch-arguments))
@@ -150,7 +151,8 @@
                                             [parent-id])) parent)
         superfetch-arguments (merge additional-filter-opts
                                     {:id           load-id
-                                     :page-options nil})
+                                     :page-options nil
+                                     :load-id      load-id})
         superfetch-id        (hash superfetch-arguments)]
     (with-superlifter (:superlifter context)
       (-> (superlifter-api/enqueue! db-key (superfetcher superfetch-id superfetch-arguments))

--- a/src/gosura/helpers/resolver2.clj
+++ b/src/gosura/helpers/resolver2.clj
@@ -4,12 +4,16 @@
             [failjure.core :as f]
             [gosura.auth :as auth]
             [gosura.helpers.error :as error]
-            [gosura.helpers.resolver :refer [parse-fdecl
-                                             keys-not-found]]
             [gosura.helpers.relay :as relay]
+            [gosura.helpers.resolver :refer [common-pre-process-arguments
+                                             keys-not-found
+                                             nullify-empty-string-arguments parse-fdecl]]
+            [gosura.helpers.superlifter :refer [with-superlifter]]
             [gosura.util :as util :refer [transform-keys->camelCaseKeyword
                                           transform-keys->kebab-case-keyword
-                                          update-resolver-result]]))
+                                          update-resolver-result]]
+            [promesa.core :as prom]
+            [superlifter.api :as superlifter-api]))
 
 (defmacro wrap-resolver-body
   "GraphQL 리졸버가 공통으로 해야 할 auth 처리, case 변환 처리를 resolver body의 앞뒤에서 해 주도록 wrapping합니다.
@@ -75,3 +79,80 @@
        (wrap-resolver-body {:ctx    ctx#
                             :arg    arg#
                             :parent parent#} ~option ~args ~body))))
+
+(defn connection-by
+  "Lacinia 리졸버로서 config 설정에 따라 목록 조회 쿼리를 처리한다.
+
+  ## 인자
+  * context   리졸버 실행 문맥
+  * arguments 쿼리 입력
+  * parent    부모 노드
+  * config    리졸버 동작 설정
+    * :superfetcher: 슈퍼페처
+    * :post-process-row: 결과 객체 목록 후처리 함수 (예: identity)
+    * :parent-id: 부모로부터 전달되는 id 값. 예) [:relay/decode-global-id->db-id :id] or :user-id
+  ## 반환
+  * 객체 목록
+  "
+  [context arguments parent {:keys [db-key
+                                     node-type
+                                     superfetcher
+                                     parent-id
+                                     post-process-row
+                                     additional-filter-opts]}]
+  {:pre [(some? db-key)]}
+  (let [arguments (-> arguments
+                      common-pre-process-arguments
+                      (nullify-empty-string-arguments [:after :before]))
+        load-id ((apply comp (if (coll? parent-id)
+                               parent-id
+                               [parent-id])) parent)
+        {:keys [order-by
+                page-direction
+                page-size
+                cursor-id]
+         :as   page-options} (relay/build-page-options arguments)
+        superfetch-arguments (merge additional-filter-opts
+                                    {:id           load-id
+                                     :page-options page-options})
+        superfetch-id (hash superfetch-arguments)]
+    (with-superlifter (:superlifter context)
+      (-> (superlifter-api/enqueue! db-key (superfetcher superfetch-id superfetch-arguments))
+          (prom/then (fn [rows]
+                       (->> rows
+                            (map #(relay/build-node % node-type post-process-row))
+                            (relay/build-connection order-by page-direction page-size cursor-id))))))))
+
+(defn one-by
+  "Lacinia 리졸버로서 config 설정에 따라 단건 조회 쿼리를 처리한다.
+
+  ## 인자
+  * context   리졸버 실행 문맥
+  * arguments 쿼리 입력
+  * parent    부모 노드
+  * config    리졸버 동작 설정
+    * :db-key            사용할 DB 이름
+    * :superfetcher      슈퍼페처
+    * :post-process-row  결과 객체 목록 후처리 함수 (예: identity)
+    * :parent-id: 부모로부터 전달되는 id 값. 예) [:relay/decode-global-id->db-id :id] or :user-id
+  ## 반환
+  * 객체 하나
+  "
+  [context _arguments parent {:keys [db-key
+                                     node-type
+                                     superfetcher
+                                     post-process-row
+                                     parent-id
+                                     additional-filter-opts]}]
+  {:pre [(some? db-key)]}
+  (let [load-id              ((apply comp (if (coll? parent-id)
+                                            parent-id
+                                            [parent-id])) parent)
+        superfetch-arguments (merge additional-filter-opts
+                                    {:id           load-id
+                                     :page-options nil})
+        superfetch-id        (hash superfetch-arguments)]
+    (with-superlifter (:superlifter context)
+      (-> (superlifter-api/enqueue! db-key (superfetcher superfetch-id superfetch-arguments))
+          (prom/then (fn [rows] (-> (first rows)
+                                    (relay/build-node node-type post-process-row))))))))

--- a/src/gosura/helpers/resolver2.clj
+++ b/src/gosura/helpers/resolver2.clj
@@ -160,6 +160,3 @@
       (-> (superlifter-api/enqueue! db-key (superfetcher superfetch-id superfetch-arguments))
           (prom/then (fn [rows] (-> (first rows)
                                     (relay/build-node node-type post-process-row))))))))
-
-(comment
-  ((or nil identity) 1))

--- a/src/gosura/helpers/resolver2.clj
+++ b/src/gosura/helpers/resolver2.clj
@@ -97,13 +97,14 @@
   [context arguments parent {:keys [db-key
                                      node-type
                                      superfetcher
-                                     {:keys [pre-fn prop] :as _parent-id}
+                                     parent-id
                                      post-process-row
                                      additional-filter-opts]}]
   {:pre [(some? db-key)]}
   (let [arguments (-> arguments
                       common-pre-process-arguments
                       (nullify-empty-string-arguments [:after :before]))
+        {:keys [pre-fn prop]} parent-id
         load-id (-> parent
                     (or pre-fn identity)
                     prop)
@@ -143,11 +144,11 @@
                                      node-type
                                      superfetcher
                                      post-process-row
-                                     {:keys [pre-fn prop]
-                                      :as   _parent-id}
+                                     parent-id
                                      additional-filter-opts]}]
   {:pre [(some? db-key)]}
-  (let [load-id (-> parent
+  (let [{:keys [pre-fn prop]} parent-id
+        load-id (-> parent
                     (or pre-fn identity)
                     prop)
         superfetch-arguments (merge additional-filter-opts

--- a/src/gosura/helpers/superlifter.clj
+++ b/src/gosura/helpers/superlifter.clj
@@ -84,18 +84,18 @@
                  (map :id)
                  (map str))
         base-filter-options (->> arguments-list first :filter-options)
-        base-relation-id (or (->> arguments-list first :prop)
+        base-aggregation-id (or (->> arguments-list first :agg)
                               id-in-parent) ; 하위호환
         batch-args (->> arguments-list
-                        (map #(dissoc % :page-options :filter-options :prop))
-                        (map #(s/rename-keys % {:id base-relation-id})))
+                        (map #(dissoc % :page-options :filter-options :agg))
+                        (map #(s/rename-keys % {:id base-aggregation-id})))
         filter-options (merge base-filter-options
                               {:batch-args batch-args})
         base-page-options (->> arguments-list first :page-options)
         page-options (dissoc base-page-options :limit)  ; (연오) foolproof: 페치할 때 LIMIT 하면 안 된다. 페치 -> ID별 그룹 -> 그룹별 LIMIT
         id->rows (->> (table-fetcher db filter-options page-options)
-                      (map #(update % base-relation-id str))  ; ids가 str로 입력되므로 맞춤
-                      (group-by base-relation-id))]
+                      (map #(update % base-aggregation-id str))  ; ids가 str로 입력되므로 맞춤
+                      (group-by base-aggregation-id))]
     (map id->rows ids))) ; rows를 ids 순서대로 배치
 
 (defmacro superfetcher-v2

--- a/src/gosura/helpers/superlifter.clj
+++ b/src/gosura/helpers/superlifter.clj
@@ -84,7 +84,7 @@
                  (map :id)
                  (map str))
         base-filter-options (->> arguments-list first :filter-options)
-        base-id-in-parent (or (->> arguments-list first :load-id)
+        base-id-in-parent (or (->> arguments-list first :prop)
                               id-in-parent) ; 하위호환
         batch-args (->> arguments-list
                         (map #(dissoc % :page-options :filter-options))

--- a/src/gosura/helpers/superlifter.clj
+++ b/src/gosura/helpers/superlifter.clj
@@ -84,16 +84,18 @@
                  (map :id)
                  (map str))
         base-filter-options (->> arguments-list first :filter-options)
+        base-id-in-parent (or (->> arguments-list first :load-id)
+                              id-in-parent) ; 하위호환
         batch-args (->> arguments-list
                         (map #(dissoc % :page-options :filter-options))
-                        (map #(s/rename-keys % {:id id-in-parent})))
+                        (map #(s/rename-keys % {:id base-id-in-parent})))
         filter-options (merge base-filter-options
                               {:batch-args batch-args})
         base-page-options (->> arguments-list first :page-options)
         page-options (dissoc base-page-options :limit)  ; (연오) foolproof: 페치할 때 LIMIT 하면 안 된다. 페치 -> ID별 그룹 -> 그룹별 LIMIT
         id->rows (->> (table-fetcher db filter-options page-options)
-                      (map #(update % id-in-parent str))  ; ids가 str로 입력되므로 맞춤
-                      (group-by id-in-parent))]
+                      (map #(update % base-id-in-parent str))  ; ids가 str로 입력되므로 맞춤
+                      (group-by base-id-in-parent))]
     (map id->rows ids))) ; rows를 ids 순서대로 배치
 
 (defmacro superfetcher-v2

--- a/src/gosura/helpers/superlifter.clj
+++ b/src/gosura/helpers/superlifter.clj
@@ -84,18 +84,18 @@
                  (map :id)
                  (map str))
         base-filter-options (->> arguments-list first :filter-options)
-        base-id-in-parent (or (->> arguments-list first :prop)
+        base-relation-id (or (->> arguments-list first :prop)
                               id-in-parent) ; 하위호환
         batch-args (->> arguments-list
                         (map #(dissoc % :page-options :filter-options :prop))
-                        (map #(s/rename-keys % {:id base-id-in-parent})))
+                        (map #(s/rename-keys % {:id base-relation-id})))
         filter-options (merge base-filter-options
                               {:batch-args batch-args})
         base-page-options (->> arguments-list first :page-options)
         page-options (dissoc base-page-options :limit)  ; (연오) foolproof: 페치할 때 LIMIT 하면 안 된다. 페치 -> ID별 그룹 -> 그룹별 LIMIT
         id->rows (->> (table-fetcher db filter-options page-options)
-                      (map #(update % base-id-in-parent str))  ; ids가 str로 입력되므로 맞춤
-                      (group-by base-id-in-parent))]
+                      (map #(update % base-relation-id str))  ; ids가 str로 입력되므로 맞춤
+                      (group-by base-relation-id))]
     (map id->rows ids))) ; rows를 ids 순서대로 배치
 
 (defmacro superfetcher-v2

--- a/src/gosura/helpers/superlifter.clj
+++ b/src/gosura/helpers/superlifter.clj
@@ -87,7 +87,7 @@
         base-id-in-parent (or (->> arguments-list first :prop)
                               id-in-parent) ; 하위호환
         batch-args (->> arguments-list
-                        (map #(dissoc % :page-options :filter-options))
+                        (map #(dissoc % :page-options :filter-options :prop))
                         (map #(s/rename-keys % {:id base-id-in-parent})))
         filter-options (merge base-filter-options
                               {:batch-args batch-args})


### PR DESCRIPTION
# 변경사항
- resolver2에 `connection-by`와 `one-by`를 추가하였습니다. 기존의 resolver에서 사용하던 `resolve-connection-by-xxx`와 
- `resolve-by-xxx`를 대체합니다.
- 공통적으로는 case변환이 중복되던 걸 제외하였습니다. (퍼포먼스 향상)
- connection-by의 경우 superfetcher 사용에 필요한 부모로부터 전달되는 필터 값을 자유롭게 조작할 수 있도록 하였습니다. (데이터화)
- one-by의 경우 superlifter 사용을 제거하였습니다. (퍼포먼스 향상)

사용해보니 큰 문제는 없고 이슈 추가해주시면 버그 수정 및 테스트 추가하겠습니다