### PR TITLE
deps.edn 파싱 오류 수정, 스펙터 제거

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ clj -M:quickdoc
 
 출시하고자 하는 버전에 해당하는 git tag를 생성하고, `build.edn` 파일을 수정한 뒤 아래 명령어를 실행합니다.
 
+환경변수에 `CLOJARS_USERNAME`와 `CLOJARS_PASSWORD`가 지정되어 있어야 합니다.
+
 ```bash
 clj -T:build deploy
 ```

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,6 @@
 {:paths   ["src" "resources" "classes"]
  :deps    {camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}
            com.github.seancorfield/honeysql    {:mvn/version "2.2.891"}
-           com.rpl/specter                     {:mvn/version "1.1.4"}
            com.taoensso/nippy                  {:mvn/version "3.1.1"}
            com.taoensso/timbre                 {:mvn/version "5.2.1"}
            com.walmartlabs/lacinia             {:mvn/version "1.1"}
@@ -26,9 +25,7 @@
 
            :build    {:deps              {com.github.liquidz/build.edn {:git/tag "0.3.90"
                                                                         :git/sha "e3a3e31"}}
-                      :ns-default        build-edn.main
-                      :deploy-repository {:username #env YOUR_USERNAME
-                                          :password #env YOUR_PASSWORD}}
+                      :ns-default        build-edn.main}
            :quickdoc {:deps      {org.babashka/cli            {:mvn/version "0.4.36"}
                                   io.github.borkdude/quickdoc {:deps/root "jvm"
                                                                :git/sha   "c5320cbe311b651a60b47f4d00d7e8ab63291b6e"}}

--- a/src/gosura/helpers/db.clj
+++ b/src/gosura/helpers/db.clj
@@ -1,6 +1,5 @@
 (ns gosura.helpers.db
   (:require [clojure.set]
-            [com.rpl.specter :as specter]
             [honey.sql :as honeysql]
             [honey.sql.helpers :as sql-helper]
             [next.jdbc :as jdbc]
@@ -99,9 +98,12 @@
   [options]
   (let [pred #(or (nil? %)
                   (and (coll? %) (empty? %)))]
-    (specter/setval [specter/MAP-VALS pred]
-                    specter/NONE
-                    options)))
+    (reduce-kv (fn [m k v]
+                 (if (pred v)
+                   m
+                   (assoc m k v)))
+               {}
+               options)))
 
 (defn join-for-filter-options
   "지정한 규칙과 필터링 옵션에 따라 조인 조건들을 선택한다.

--- a/test/gosura/helpers/db_test.clj
+++ b/test/gosura/helpers/db_test.clj
@@ -2,6 +2,12 @@
   (:require [clojure.test :refer [deftest is testing run-tests]]
             [gosura.helpers.db :as db]))
 
+(deftest utility-test
+  (testing "remove-empty-options"
+    (let [options {:a 1, :b [1 2 3], :c [], :d {}, :e nil, :f #{1 2}}]
+      (is (= {:a 1, :b [1 2 3], :f #{1 2}}
+             (db/remove-empty-options options))))))
+
 (deftest batch-args-filter-pred-test
   (testing "batch-args를 HoneySQL에서 사용할 수 있는 데이터로 반환합니다."
     (let [result (db/batch-args-filter-pred


### PR DESCRIPTION
deps.edn 에 reader macro가 사용되고 있어 인텔리제이로 프로젝트를 열었을 때 오류가 발생합니다.
https://github.com/liquidz/build.edn/blob/main/doc/deploy.adoc#environmental-variables

specter 도 제거했습니다. (굳이 쓸 이유가 없는데 의존성만 추가되기 때문)