### PR TITLE
tagged literal 지원을 위해 사용되는 aero 제거

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,7 @@
-{:paths   ["src" "resources" "classes"]
+{:paths   ["src"]
  :deps    {camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.3"}
            com.github.seancorfield/honeysql    {:mvn/version "2.2.891"}
+           com.github.seancorfield/next.jdbc   {:mvn/version "1.2.780"}
            com.taoensso/nippy                  {:mvn/version "3.1.1"}
            com.taoensso/timbre                 {:mvn/version "5.2.1"}
            com.walmartlabs/lacinia             {:mvn/version "1.1"}
@@ -13,9 +14,7 @@
            org.clojure/core.match              {:mvn/version "1.0.0"}
            superlifter/superlifter             {:git/url "https://github.com/green-labs/superlifter.git"
                                                 :sha     "e0df5b36b496c485c75f38052a71b18f02772cc0"}
-           metosin/malli                       {:mvn/version "0.8.4"}
-           com.github.seancorfield/next.jdbc   {:mvn/version "1.2.780"}
-           aero/aero                           {:mvn/version "1.1.6"}}
+           metosin/malli                       {:mvn/version "0.8.4"}}
 
  :aliases {:test     {:extra-paths ["test"]
                       :extra-deps  {io.github.cognitect-labs/test-runner {:git/tag "v0.5.0"

--- a/src/gosura/edn.clj
+++ b/src/gosura/edn.clj
@@ -1,10 +1,14 @@
 (ns gosura.edn
-  (:require [aero.core :as aero]))
-
-(defmethod aero/reader 'var
-  [_opts _tag value]
-  (requiring-resolve value))
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io])
+  (:import (java.io PushbackReader)))
 
 (defn read-config
+  "edn 형식의 설정파일을 불러들임.
+  tagged literal `#var`를 지원하기 위해 사용한다.
+  "
   [path]
-  (aero/read-config path))
+  (with-open [r (io/reader path)]
+    (edn/read {:readers (merge default-data-readers
+                               {'var requiring-resolve})}
+              (PushbackReader. r))))


### PR DESCRIPTION
aero 의존성이 `#var` 를 파싱하기 위해 사용되고 있습니다.

이를 기본 edn/read + data_reader 설정으로 바꾸었습니다.