### PR TITLE
superlifter의 정의를 gosura config에서 대신합니다

### DIFF
--- a/src/gosura/helpers/resolver2.clj
+++ b/src/gosura/helpers/resolver2.clj
@@ -122,12 +122,13 @@
                                      :page-options page-options
                                      :agg          agg})
         superfetch-id (hash superfetch-arguments)
-        superfetcher-name (gensym (str "FetchBy" (csk/->PascalCase (name prop))))
-        ->superfetcher-name (symbol (str "->" superfetcher-name))
-        _ `(superfetcher-v2 ~superfetcher-name {:db-key        ~db-key
-                                                :table-fetcher ~fetch})]
+        superfetcher-name (symbol (str "FetchBy" (csk/->PascalCase (name prop))))
+        map->superfetcher-name (symbol (str "map->" superfetcher-name))]
+    (eval `(superfetcher-v2 ~superfetcher-name {:db-key        ~db-key
+                                                :table-fetcher ~fetch}))
     (with-superlifter (:superlifter context)
-      (-> (superlifter-api/enqueue! db-key (->superfetcher-name superfetch-id superfetch-arguments))
+      (-> (superlifter-api/enqueue! db-key (eval `(~map->superfetcher-name {:id        ~superfetch-id
+                                                                            :arguments ~superfetch-arguments})))
           (prom/then (fn [rows]
                        (->> rows
                             (map #(relay/build-node % node-type post-process-row))
@@ -165,12 +166,13 @@
                                           :page-options nil
                                           :agg          agg})
         superfetch-id             (hash superfetch-arguments)
-        superfetcher-name         (gensym (str "FetchBy" (csk/->PascalCase (name prop))))
-        ->superfetcher-name       (symbol (str "->" superfetcher-name))
-        _              `(superfetcher-v2 ~superfetcher-name {:db-key        ~db-key
-                                                             :table-fetcher ~fetch})]
+        superfetcher-name (symbol (str "FetchBy" (csk/->PascalCase (name prop))))
+        map->superfetcher-name (symbol (str "map->" superfetcher-name))]
+    (eval `(superfetcher-v2 ~superfetcher-name {:db-key        ~db-key
+                                                :table-fetcher ~fetch}))
     (with-superlifter (:superlifter context)
-      (-> (superlifter-api/enqueue! db-key (->superfetcher-name superfetch-id superfetch-arguments))
+      (-> (superlifter-api/enqueue! db-key (eval `(~map->superfetcher-name {:id        ~superfetch-id
+                                                                            :arguments ~superfetch-arguments})))
           (prom/then (fn [rows] (-> (first rows)
                                     (relay/build-node node-type post-process-row)
                                     transform-keys->camelCaseKeyword)))))))

--- a/src/gosura/helpers/resolver2.clj
+++ b/src/gosura/helpers/resolver2.clj
@@ -9,7 +9,8 @@
             [gosura.helpers.resolver :refer [common-pre-process-arguments
                                              keys-not-found
                                              nullify-empty-string-arguments parse-fdecl]]
-            [gosura.helpers.superlifter :refer [with-superlifter]]
+            [gosura.helpers.superlifter :refer [with-superlifter
+                                                superfetcher-v2]]
             [gosura.util :as util :refer [transform-keys->camelCaseKeyword
                                           transform-keys->kebab-case-keyword
                                           update-resolver-result]]
@@ -124,10 +125,11 @@
                                      :agg          agg})
         superfetch-id (hash superfetch-arguments)
         superfetcher-name (gensym (str "FetchBy" (csk/->PascalCase (name prop))))
-        superfetcher `(superfetcher-v2 ~superfetcher-name {:db-key        ~db-key
-                                                           :table-fetcher ~fetch})]
+        ->superfetcher-name (symbol (str "->" superfetcher-name))
+        _ `(superfetcher-v2 ~superfetcher-name {:db-key        ~db-key
+                                                :table-fetcher ~fetch})]
     (with-superlifter (:superlifter context)
-      (-> (superlifter-api/enqueue! db-key (superfetcher superfetch-id superfetch-arguments))
+      (-> (superlifter-api/enqueue! db-key (->superfetcher-name superfetch-id superfetch-arguments))
           (prom/then (fn [rows]
                        (->> rows
                             (map #(relay/build-node % node-type post-process-row))
@@ -168,10 +170,11 @@
                                           :agg          agg})
         superfetch-id             (hash superfetch-arguments)
         superfetcher-name         (gensym (str "FetchBy" (csk/->PascalCase (name prop))))
-        superfetcher              `(superfetcher-v2 ~superfetcher-name {:db-key        ~db-key
-                                                                        :table-fetcher ~fetch})]
+        ->superfetcher-name       (symbol (str "->" superfetcher-name))
+        _              `(superfetcher-v2 ~superfetcher-name {:db-key        ~db-key
+                                                             :table-fetcher ~fetch})]
     (with-superlifter (:superlifter context)
-      (-> (superlifter-api/enqueue! db-key (superfetcher superfetch-id superfetch-arguments))
+      (-> (superlifter-api/enqueue! db-key (->superfetcher-name superfetch-id superfetch-arguments))
           (prom/then (fn [rows] (-> (first rows)
                                     (relay/build-node node-type post-process-row)
                                     transform-keys->camelCaseKeyword)))))))


### PR DESCRIPTION
# 주요 변경 사항
- connection-by와 one-by 시 gosura 설정 방식이 변경되었습니다.
- 가장 큰 변화는 superfetcher 정의를 생략하고, superfecther가 아닌 그냥 fetch 함수를 설정하도록 하였습니다.

변경 전
;; FetchByXXX가 defrecord로서(superlifter로서) 정의되어 있었어야함
```clojure
{:connection-by-xxx {:superfetcher #var my-ns/->FetchByxxx :parent-id {:prop :xxx :agg  :aaa}}}
```

변경 후
```clojure
{:connection-by-xxx {:fetch #var my-ns/my-fetch :parent-id {:prop :xxx :agg  :aaa}}}
```

로 사용할 수 있음.

즉, superlifter 정의를 따로 할 필요 없이 N+1 쿼리의 논리적 전개를 설정값에서 바로 할 수 있음.

그와 별개로 코드 자체가 깨끗해보이지 않는 문제가 있음. 🙏 