### PR TITLE
TOMATO-855 generate-all 시 superfetcher를 생성하고 one-by 호출시 생성된 superfetcher 호출하도록 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ pom.xml.asc
 gosura.iml
 
 .clj-kondo/com.github.seancorfield
+.portal

--- a/src/gosura/core.clj
+++ b/src/gosura/core.clj
@@ -170,7 +170,8 @@
                                                    _ (when (seq required-keys)
                                                        (f/fail (format "%s keys are needed in parent" required-keys)))
                                                    resolver-fn (find-resolver-fn resolver)
-                                                   added-params (merge params {:additional-filter-opts (merge auth-filter-opts
+                                                   added-params (merge params {:target-ns target-ns
+                                                                               :additional-filter-opts (merge auth-filter-opts
                                                                                                               config-filter-opts)})]
                                                   (cond-> (resolver-fn ctx args parent added-params)
                                                     return-camel-case? (util/update-resolver-result transform-keys->camelCaseKeyword))

--- a/src/gosura/helpers/resolver2.clj
+++ b/src/gosura/helpers/resolver2.clj
@@ -1,6 +1,7 @@
 (ns gosura.helpers.resolver2
   "gosura.helpers.resolver의 v2입니다."
-  (:require [com.walmartlabs.lacinia.resolve :refer [resolve-as]]
+  (:require [camel-snake-kebab.core :as csk]
+            [com.walmartlabs.lacinia.resolve :refer [resolve-as]]
             [failjure.core :as f]
             [gosura.auth :as auth]
             [gosura.helpers.error :as error]
@@ -134,8 +135,8 @@
   * arguments 쿼리 입력
   * parent    부모 노드
   * config    리졸버 동작 설정
-    * :db-key            사용할 DB 이름
-    * :superfetcher      슈퍼페처
+    * :db-key 사용할 DB 이름
+    * :fetch fetch 함수
     * :post-process-row  결과 객체 목록 후처리 함수 (예: identity)
     * :parent-id: 부모로부터 전달되는 id 정보 예) {:pre-fn relay/decode-global-id->db-id :prop :id :agg :id} {:prop :user-id :agg :id}
      * :pre-fn: 전처리
@@ -146,7 +147,7 @@
   "
   [context _arguments parent {:keys [db-key
                                      node-type
-                                     superfetcher
+                                     fetch
                                      post-process-row
                                      parent-id
                                      additional-filter-opts]}]
@@ -157,9 +158,13 @@
                                          {:id           load-id
                                           :page-options nil
                                           :agg          agg})
-        superfetch-id             (hash superfetch-arguments)]
+        superfetch-id             (hash superfetch-arguments)
+        superfetcher-name (symbol (str "FetchBy" (csk/->PascalCase (name prop))))
+        map->superfetcher-name (symbol (str "map->" superfetcher-name))]
+
     (with-superlifter (:superlifter context)
-      (-> (superlifter-api/enqueue! db-key (superfetcher superfetch-id superfetch-arguments))
+      (-> (superlifter-api/enqueue! db-key (eval `(~map->superfetcher-name {:id        ~superfetch-id
+                                                                            :arguments ~superfetch-arguments})))
           (prom/then (fn [rows] (-> (first rows)
                                     (relay/build-node node-type post-process-row)
                                     transform-keys->camelCaseKeyword)))))))

--- a/src/gosura/helpers/resolver2.clj
+++ b/src/gosura/helpers/resolver2.clj
@@ -145,7 +145,8 @@
   ## 반환
   * 객체 하나
   "
-  [context _arguments parent {:keys [db-key
+  [context _arguments parent {:keys [target-ns
+                                     db-key
                                      node-type
                                      fetch
                                      post-process-row
@@ -160,7 +161,7 @@
                                           :agg          agg})
         superfetch-id             (hash superfetch-arguments)
         superfetcher-name (symbol (str "FetchBy" (csk/->PascalCase (name prop))))
-        map->superfetcher-name (symbol (str "map->" superfetcher-name))]
+        map->superfetcher-name (symbol (str target-ns "/map->" superfetcher-name))]
 
     (with-superlifter (:superlifter context)
       (-> (superlifter-api/enqueue! db-key (eval `(~map->superfetcher-name {:id        ~superfetch-id

--- a/src/gosura/helpers/resolver2.clj
+++ b/src/gosura/helpers/resolver2.clj
@@ -150,7 +150,7 @@
                                      fetch
                                      post-process-row
                                      parent-id
-                                     additional-filter-opts]}]
+                                     additional-filter-opts] :as _config}]
   {:pre [(some? db-key)]}
   (let [{:keys [pre-fn prop agg]} parent-id
         load-id                   ((or pre-fn identity) (prop parent))

--- a/test/gosura/core_test.clj
+++ b/test/gosura/core_test.clj
@@ -1,6 +1,6 @@
 (ns gosura.core-test
   (:require [clojure.set :as set]
-            [clojure.test :refer [deftest is testing]]
+            [clojure.test :refer [deftest is run-test testing]]
             [failjure.core :as f]
             [gosura.core :as gosura]
             [gosura.edn :refer [read-config]]
@@ -46,3 +46,6 @@
   #_(testing "resolve-by-fk가 정상 작동한다")
   #_(testing "resolve-by-example-id가 정상 작동한다")
   #_(testing "resolve-node가 정상 작동한다"))
+
+(comment
+  (run-test gosura-resolver-generate-one-test))

--- a/test/resources/gosura/sample_resolver_configs.edn
+++ b/test/resources/gosura/sample_resolver_configs.edn
@@ -7,4 +7,8 @@
                                   :table-fetcher clojure.core/identity}
              :resolve-by-fk      {:settings     {:auth clojure.core/identity}
                                   :superfetcher clojure.core/identity
-                                  :fk-in-parent :test-id}}}
+                                  :fk-in-parent :test-id}
+             :one-by-xxx         {:settings  {:auth clojure.core/identity}
+                                  :fetch     #var clojure.core/identity
+                                  :parent-id {:prop :xxx
+                                              :agg :aaa}}}}


### PR DESCRIPTION
- [TOMATO-855](https://green-labs.atlassian.net/browse/TOMATO-855)
- https://github.com/green-labs/gosura/commit/df36a45eaee6ddf1fc456f72b43528d38c4947cc 에서 메모리릭 이 있었던 부분을 수정하여 generate-all 내부에서 superfetcher를 생성하도록 변경
- https://github.com/green-labs/farmmorning-clj/pull/1997 PR에서 동작 확인했습니다.
- superfetcher를 찾을 때 target-ns가 필요해서 추가로 넘겼습니다.
  - one-by를 직접 호출할 때 superfetcher의 target-ns를 넘기는 것이 조금 미묘해 보이긴 합니다.