### PR TITLE
Decode-base64-encoded-vals

### DIFF
--- a/src/gosura/helpers/relay.clj
+++ b/src/gosura/helpers/relay.clj
@@ -253,6 +253,42 @@
                {}
                arguments)))
 
+(defmulti decode-all-global-ids
+  (fn [arguments]
+    (type arguments)))
+
+(defmethod decode-all-global-ids clojure.lang.PersistentVector
+  [args]
+  (reduce-kv (fn [acc k v]
+               (assoc acc k (decode-all-global-ids v)))
+             []
+             args))
+
+(defmethod decode-all-global-ids clojure.lang.PersistentList
+  [args]
+  (reduce-kv (fn [acc k v]
+               (assoc acc k (decode-all-global-ids v)))
+             '()
+             args))
+
+(defmethod decode-all-global-ids clojure.lang.IPersistentMap
+  [args]
+  (reduce-kv (fn [acc k v]
+               (assoc acc k (decode-all-global-ids v)))
+             {}
+             args))
+
+(defmethod decode-all-global-ids java.lang.String
+  [v]
+  (try
+    (decode-global-id->db-id v)
+    (catch Exception _
+      v)))
+
+(defmethod decode-all-global-ids :default
+  [v]
+  v)
+
 (comment
   (decode-cursor "TlBZAHFkAW4BZAE=")  ;; => {:id 1, :ordered-values [1]})
   (decode-cursor "b2Zmc2V0OjM=")      ;; => {:offset "3"}

--- a/test/gosura/helpers/relay_test.clj
+++ b/test/gosura/helpers/relay_test.clj
@@ -500,8 +500,43 @@
                                                     :b "bm90aWNlOjEwMA=="
                                                     :c {:d ["bm90aWNlOjEwMA==" "bm90aWNlOjEwMA=="]}}
                                                    [:a :d])
-           {:a "100", :b "bm90aWNlOjEwMA==", :c {:d ["100" "100"]}}))))
+           {:a "100"
+            :b "bm90aWNlOjEwMA=="
+            :c {:d ["100" "100"]}}))))
+
+(deftest decode-all-global-ids
+  (testing "decode key"
+    (is (= (gosura-relay/decode-all-global-ids {:a "bm90aWNlOjEwMA=="})
+           {:a "100"})))
+  (testing "decode vector"
+    (is (= (gosura-relay/decode-all-global-ids ["bm90aWNlOjEwMA==" "bm90aWNlOjEwMA=="])
+           ["100" "100"])))
+  (testing "decode vector in map"
+    (is (= (gosura-relay/decode-all-global-ids {:a ["bm90aWNlOjEwMA==" "bm90aWNlOjEwMA=="]})
+           {:a ["100" "100"]})))
+  (testing "nested"
+    (is (= (gosura-relay/decode-all-global-ids {:a "bm90aWNlOjEwMA=="
+                                                :b "bm90aWNlOjEwMA=="
+                                                :c {:d ["bm90aWNlOjEwMA==" "bm90aWNlOjEwMA=="]}})
+           {:a "100"
+            :b "100"
+            :c {:d ["100" "100"]}})))
+  (testing "not encoded string is okay"
+    (is (= (gosura-relay/decode-all-global-ids {:a "bm90aWNlOjEwMA=="
+                                                :b "100"
+                                                :c {:d ["bm90aWNlOjEwMA==" "bm90aWNlOjEwMA=="]}})
+           {:a "100"
+            :b "100"
+            :c {:d ["100" "100"]}})))
+  (testing "keyword and number is okay"
+    (is (= (gosura-relay/decode-all-global-ids {:a "bm90aWNlOjEwMA=="
+                                                :b 100
+                                                :f :100
+                                                :c {:d ["bm90aWNlOjEwMA==" "bm90aWNlOjEwMA=="]}})
+           {:a "100"
+            :b 100
+            :f :100
+            :c {:d ["100" "100"]}}))))
 
 (comment
-  (run-tests)
-  )
+  (run-tests))


### PR DESCRIPTION
- defresolver2에서 option으로 `:decode-base64-encoded-vals` 옵션을 추가했습니다.
- 기본값은 true이고, base64 인코딩을 할 수 있는 경우에는 무적권하도록 했습니다.