### PR TITLE
defresolver2 에 errors type, info 추가 및 stacktrace 원본 출력, clojure.tools.logging/error 호출

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -8,7 +8,6 @@
            io.github.hlship/trace              {:git/url "https://github.com/jungwookim/trace"
                                                 :git/sha "27e0faf04fa865d902730da9b944053445f0be7d"}
            io.sentry/sentry-clj                {:mvn/version "5.7.180"}
-           io.aviso/pretty                     {:mvn/version "1.3"}
            medley/medley                       {:mvn/version "1.4.0"}
            org.apache.commons/commons-lang3    {:mvn/version "3.12.0"}
            org.clojure/clojure                 {:mvn/version "1.11.1"}

--- a/deps.edn
+++ b/deps.edn
@@ -8,6 +8,7 @@
            io.github.hlship/trace              {:git/url "https://github.com/jungwookim/trace"
                                                 :git/sha "27e0faf04fa865d902730da9b944053445f0be7d"}
            io.sentry/sentry-clj                {:mvn/version "5.7.180"}
+           io.aviso/pretty                     {:mvn/version "1.3"}
            medley/medley                       {:mvn/version "1.4.0"}
            org.apache.commons/commons-lang3    {:mvn/version "3.12.0"}
            org.clojure/clojure                 {:mvn/version "1.11.1"}

--- a/deps.edn
+++ b/deps.edn
@@ -9,7 +9,6 @@
                                                 :git/sha "27e0faf04fa865d902730da9b944053445f0be7d"}
            io.sentry/sentry-clj                {:mvn/version "5.7.180"}
            medley/medley                       {:mvn/version "1.4.0"}
-           org.apache.commons/commons-lang3    {:mvn/version "3.12.0"}
            org.clojure/clojure                 {:mvn/version "1.11.1"}
            org.clojure/tools.logging           {:mvn/version "1.2.4"}
            org.clojure/core.match              {:mvn/version "1.0.0"}

--- a/src/gosura/helpers/error.clj
+++ b/src/gosura/helpers/error.clj
@@ -1,8 +1,6 @@
 (ns gosura.helpers.error
-  (:require [clojure.string :as string]
-            [com.walmartlabs.lacinia.resolve :refer [resolve-as]]
-            [gosura.helpers.error :as error]
-            [io.aviso.exception :as e]))
+  (:require [com.walmartlabs.lacinia.resolve :refer [resolve-as]]
+            [gosura.helpers.error :as error]))
 
 (defn error
   "resolve-as를 사용하여 error를 반환하고 기본적으로 값으로는 nil을 반환하도록 한다"
@@ -10,31 +8,3 @@
    (error nil resolver-errors))
   ([resolved-value resolver-errors]
    (resolve-as resolved-value resolver-errors)))
-
-(defn- stack-trace->formatted
-  [{:keys [formatted-name file line]}]
-  (if line
-    (str formatted-name " (" file ":" line ")")
-    formatted-name))
-
-(defn analyzed->formatted [analyses]
-  (update analyses :stack-trace
-          (fn [stack-trace]
-            (when stack-trace (map stack-trace->formatted stack-trace)))))
-
-(defn- extract-fn-name [clj-classname]
-  (->> (string/split clj-classname #"\$")
-       (map e/demangle)
-       (string/join "/")))
-
-(defn- take-primary-analyze [analyses]
-  (->> analyses
-       (drop-while #(not (:stack-trace %)))
-       first
-       :stack-trace
-       first))
-
-(defn primary-trace [analyses]
-  (let [primary-analyze (take-primary-analyze analyses)]
-    {:in   (extract-fn-name (:class primary-analyze))
-     :line (:line primary-analyze)}))

--- a/src/gosura/helpers/error.clj
+++ b/src/gosura/helpers/error.clj
@@ -1,6 +1,5 @@
 (ns gosura.helpers.error
-  (:require [com.walmartlabs.lacinia.resolve :refer [resolve-as]]
-            [gosura.helpers.error :as error]))
+  (:require [com.walmartlabs.lacinia.resolve :refer [resolve-as]]))
 
 (defn error
   "resolve-as를 사용하여 error를 반환하고 기본적으로 값으로는 nil을 반환하도록 한다"

--- a/src/gosura/helpers/error.clj
+++ b/src/gosura/helpers/error.clj
@@ -1,5 +1,8 @@
 (ns gosura.helpers.error
-  (:require [com.walmartlabs.lacinia.resolve :refer [resolve-as]]))
+  (:require [clojure.string :as string]
+            [com.walmartlabs.lacinia.resolve :refer [resolve-as]]
+            [gosura.helpers.error :as error]
+            [io.aviso.exception :as e]))
 
 (defn error
   "resolve-as를 사용하여 error를 반환하고 기본적으로 값으로는 nil을 반환하도록 한다"
@@ -7,3 +10,31 @@
    (error nil resolver-errors))
   ([resolved-value resolver-errors]
    (resolve-as resolved-value resolver-errors)))
+
+(defn- stack-trace->formatted
+  [{:keys [formatted-name file line]}]
+  (if line
+    (str formatted-name " (" file ":" line ")")
+    formatted-name))
+
+(defn analyzed->formatted [analyses]
+  (update analyses :stack-trace
+          (fn [stack-trace]
+            (when stack-trace (map stack-trace->formatted stack-trace)))))
+
+(defn- extract-fn-name [clj-classname]
+  (->> (string/split clj-classname #"\$")
+       (map e/demangle)
+       (string/join "/")))
+
+(defn- take-primary-analyze [analyses]
+  (->> analyses
+       (drop-while #(not (:stack-trace %)))
+       first
+       :stack-trace
+       first))
+
+(defn primary-trace [analyses]
+  (let [primary-analyze (take-primary-analyze analyses)]
+    {:in   (extract-fn-name (:class primary-analyze))
+     :line (:line primary-analyze)}))

--- a/src/gosura/helpers/resolver2.clj
+++ b/src/gosura/helpers/resolver2.clj
@@ -13,7 +13,6 @@
             [gosura.util :as util :refer [transform-keys->camelCaseKeyword
                                           transform-keys->kebab-case-keyword
                                           update-resolver-result]]
-            [io.aviso.exception :as e]
             [io.aviso.repl :as aviso-repl]
             [promesa.core :as prom]
             [superlifter.api :as superlifter-api])

--- a/src/gosura/helpers/resolver2.clj
+++ b/src/gosura/helpers/resolver2.clj
@@ -24,7 +24,7 @@
          (resolve-as
           nil
           {:message    (ex-message e#)
-           :info       (ex-data e#)
+           :info       (str e#)
            :type       (.getName (class e#))
            :stacktrace (->> (.getStackTrace e#)
                             (map str))})))

--- a/src/gosura/helpers/resolver2.clj
+++ b/src/gosura/helpers/resolver2.clj
@@ -28,7 +28,7 @@
          (resolve-as
           nil
           {:message           (ex-message e#)
-           :type              (type e#)
+           :type              (.getName (class e))
            :stacktrace        (->> (ExceptionUtils/getStackTrace e#)
                                    (string/split-lines)
                                    (map #(string/replace-first % #"\t" "  ")))})))

--- a/src/gosura/helpers/resolver2.clj
+++ b/src/gosura/helpers/resolver2.clj
@@ -26,7 +26,8 @@
           {:message    (ex-message e#)
            :info       (ex-data e#)
            :type       (.getName (class e#))
-           :stacktrace (.getStackTrace e#)})))
+           :stacktrace (->> (.getStackTrace e#)
+                            (map str))})))
     body))
 
 (defmacro wrap-resolver-body

--- a/src/gosura/helpers/resolver2.clj
+++ b/src/gosura/helpers/resolver2.clj
@@ -1,7 +1,6 @@
 (ns gosura.helpers.resolver2
   "gosura.helpers.resolver의 v2입니다."
-  (:require [clojure.string :as string]
-            [com.walmartlabs.lacinia.resolve :refer [resolve-as]]
+  (:require [com.walmartlabs.lacinia.resolve :refer [resolve-as]]
             [failjure.core :as f]
             [gosura.auth :as auth]
             [gosura.helpers.error :as error]
@@ -14,8 +13,7 @@
                                           transform-keys->kebab-case-keyword
                                           update-resolver-result]]
             [promesa.core :as prom]
-            [superlifter.api :as superlifter-api])
-  (:import [org.apache.commons.lang3.exception ExceptionUtils]))
+            [superlifter.api :as superlifter-api]))
 
 (defmacro wrap-catch-body
   [catch-exceptions? body]
@@ -25,11 +23,10 @@
        (catch Exception e#
          (resolve-as
           nil
-          {:message           (ex-message e#)
-           :type              (.getName (class e#))
-           :stacktrace        (->> (ExceptionUtils/getStackTrace e#)
-                                   (string/split-lines)
-                                   (map #(string/replace-first % #"\t" "  ")))})))
+          {:message    (ex-message e#)
+           :info       (ex-data e#)
+           :type       (.getName (class e#))
+           :stacktrace (.getStackTrace e#)})))
     body))
 
 (defmacro wrap-resolver-body

--- a/src/gosura/helpers/resolver2.clj
+++ b/src/gosura/helpers/resolver2.clj
@@ -28,7 +28,7 @@
          (resolve-as
           nil
           {:message           (ex-message e#)
-           :type              (.getName (class e))
+           :type              (.getName (class e#))
            :stacktrace        (->> (ExceptionUtils/getStackTrace e#)
                                    (string/split-lines)
                                    (map #(string/replace-first % #"\t" "  ")))})))

--- a/src/gosura/helpers/resolver2.clj
+++ b/src/gosura/helpers/resolver2.clj
@@ -14,6 +14,7 @@
                                           transform-keys->kebab-case-keyword
                                           update-resolver-result]]
             [io.aviso.exception :as e]
+            [io.aviso.repl :as aviso-repl]
             [promesa.core :as prom]
             [superlifter.api :as superlifter-api])
   (:import [org.apache.commons.lang3.exception ExceptionUtils]))
@@ -24,17 +25,14 @@
     `(try
        ~@body
        (catch Exception e#
-         (let [stacktrace# (ExceptionUtils/getStackTrace e#)
-               analyses#   (e/analyze-exception e# nil)]
-           (resolve-as
-            nil
-            {:message           (.getMessage e#)
-             :trace             (error/primary-trace analyses#)
-             :pretty            (map error/analyzed->formatted analyses#)
-             :stacktrace        (->> stacktrace#
-                                     (string/split-lines)
-                                     (map #(string/replace-first % #"\t" "  ")))
-             :print-stack-trace stacktrace#}))))
+         (aviso-repl/pretty-pst e# 10)
+         (resolve-as
+          nil
+          {:message           (ex-message e#)
+           :type              (type e#)
+           :stacktrace        (->> (ExceptionUtils/getStackTrace e#)
+                                   (string/split-lines)
+                                   (map #(string/replace-first % #"\t" "  ")))})))
     body))
 
 (defmacro wrap-resolver-body

--- a/src/gosura/helpers/resolver2.clj
+++ b/src/gosura/helpers/resolver2.clj
@@ -13,7 +13,6 @@
             [gosura.util :as util :refer [transform-keys->camelCaseKeyword
                                           transform-keys->kebab-case-keyword
                                           update-resolver-result]]
-            [io.aviso.repl :as aviso-repl]
             [promesa.core :as prom]
             [superlifter.api :as superlifter-api])
   (:import [org.apache.commons.lang3.exception ExceptionUtils]))
@@ -24,7 +23,6 @@
     `(try
        ~@body
        (catch Exception e#
-         (aviso-repl/pretty-pst e# 10)
          (resolve-as
           nil
           {:message           (ex-message e#)

--- a/src/gosura/helpers/resolver2.clj
+++ b/src/gosura/helpers/resolver2.clj
@@ -1,6 +1,7 @@
 (ns gosura.helpers.resolver2
   "gosura.helpers.resolver의 v2입니다."
-  (:require [com.walmartlabs.lacinia.resolve :refer [resolve-as]]
+  (:require [clojure.tools.logging :as log]
+            [com.walmartlabs.lacinia.resolve :refer [resolve-as]]
             [failjure.core :as f]
             [gosura.auth :as auth]
             [gosura.helpers.error :as error]
@@ -21,6 +22,7 @@
     `(try
        ~@body
        (catch Exception e#
+         (log/error e#)
          (resolve-as
           nil
           {:message    (ex-message e#)

--- a/src/gosura/helpers/resolver2.clj
+++ b/src/gosura/helpers/resolver2.clj
@@ -1,7 +1,6 @@
 (ns gosura.helpers.resolver2
   "gosura.helpers.resolver의 v2입니다."
-  (:require [clojure.tools.logging :as log]
-            [com.walmartlabs.lacinia.resolve :refer [resolve-as]]
+  (:require [com.walmartlabs.lacinia.resolve :refer [resolve-as]]
             [failjure.core :as f]
             [gosura.auth :as auth]
             [gosura.helpers.error :as error]
@@ -22,7 +21,6 @@
     `(try
        ~@body
        (catch Exception e#
-         (log/error e#)
          (resolve-as
           nil
           {:message    (ex-message e#)

--- a/test/gosura/helpers/resolver_test.clj
+++ b/test/gosura/helpers/resolver_test.clj
@@ -1,7 +1,7 @@
 (ns gosura.helpers.resolver-test
   (:require [clojure.test :refer [are deftest is run-tests testing]]
             [gosura.helpers.resolver :as gosura-resolver]
-            [gosura.helpers.resolver2 :as gosura-resolver2]) 
+            [gosura.helpers.resolver2 :as gosura-resolver2])
   (:import [clojure.lang ExceptionInfo]))
 
 (deftest decode-global-id-in-arguments-test
@@ -214,10 +214,16 @@
           parent {}
           resolved (test-resolver-7 ctx arg parent)
           message (get-in resolved [:resolved-value :data :message])
-          stacktrace (get-in resolved [:resolved-value :data :stacktrace])]
+          trace (get-in resolved [:resolved-value :data :trace])
+          pretty (get-in resolved [:resolved-value :data :pretty])
+          stacktrace (get-in resolved [:resolved-value :data :stacktrace])
+          print-stack-trace (get-in resolved [:resolved-value :data :print-stack-trace])]
       (are [expected result] (= expected result)
         "something wrong!" message
-        (some? stacktrace) true)))
+        (some? trace) true
+        (some? pretty) true
+        (some? stacktrace) true
+        (some? print-stack-trace) true)))
   (testing "catch-exceptions? 설정이 false일 때 에러가 던져지면 그대로 throw한다"
     (let [_            (gosura-resolver2/defresolver test-resolver-8
                          {:catch-exceptions? false}

--- a/test/gosura/helpers/resolver_test.clj
+++ b/test/gosura/helpers/resolver_test.clj
@@ -214,16 +214,13 @@
           parent {}
           resolved (test-resolver-7 ctx arg parent)
           message (get-in resolved [:resolved-value :data :message])
-          trace (get-in resolved [:resolved-value :data :trace])
-          pretty (get-in resolved [:resolved-value :data :pretty])
-          stacktrace (get-in resolved [:resolved-value :data :stacktrace])
-          print-stack-trace (get-in resolved [:resolved-value :data :print-stack-trace])]
+          type' (get-in resolved [:resolved-value :data :type])
+          stacktrace (get-in resolved [:resolved-value :data :stacktrace])]
       (are [expected result] (= expected result)
         "something wrong!" message
-        (some? trace) true
-        (some? pretty) true
-        (some? stacktrace) true
-        (some? print-stack-trace) true)))
+        (some? type') true
+        (some? stacktrace) true)))
+
   (testing "catch-exceptions? 설정이 false일 때 에러가 던져지면 그대로 throw한다"
     (let [_            (gosura-resolver2/defresolver test-resolver-8
                          {:catch-exceptions? false}

--- a/test/gosura/helpers/resolver_test.clj
+++ b/test/gosura/helpers/resolver_test.clj
@@ -220,7 +220,6 @@
         "something wrong!" message
         (some? type') true
         (some? stacktrace) true)))
-
   (testing "catch-exceptions? 설정이 false일 때 에러가 던져지면 그대로 throw한다"
     (let [_            (gosura-resolver2/defresolver test-resolver-8
                          {:catch-exceptions? false}

--- a/test/gosura/helpers/resolver_test.clj
+++ b/test/gosura/helpers/resolver_test.clj
@@ -214,10 +214,12 @@
           parent {}
           resolved (test-resolver-7 ctx arg parent)
           message (get-in resolved [:resolved-value :data :message])
+          info (get-in resolved [:resolved-value :data :info])
           type' (get-in resolved [:resolved-value :data :type])
           stacktrace (get-in resolved [:resolved-value :data :stacktrace])]
       (are [expected result] (= expected result)
-        "something wrong!" message
+        "something wrong!"  message
+        "clojure.lang.ExceptionInfo: something wrong! {}" info
         (some? type') true
         (some? stacktrace) true)))
   (testing "catch-exceptions? 설정이 false일 때 에러가 던져지면 그대로 throw한다"


### PR DESCRIPTION
<img width="1604" alt="image" src="https://user-images.githubusercontent.com/5603687/209918558-753daad0-a317-463c-a474-15253af60f7d.png">

```json
{
  "data": null,
  "errors": [
    {
      "message": "something wrong",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "features"
      ],
      "extensions": {
        "type": "clojure.lang.ExceptionInfo",
        "info": "clojure.lang.ExceptionInfo: something wrong {}",
        "stacktrace": [
          "farmmy.core_api.feature_flag.resolve$features$fn__76033.invoke(resolve.clj:7)",
          "farmmy.core_api.feature_flag.resolve$features.invokeStatic(resolve.clj:5)",
          "farmmy.core_api.feature_flag.resolve$features.invoke(resolve.clj:5)",
          "com.walmartlabs.lacinia.schema$wrap_resolver_to_ensure_resolver_result$fn__25264.invoke(schema.clj:986)",
          "com.walmartlabs.lacinia.executor$invoke_resolver_for_field.invokeStatic(executor.clj:86)",
          "com.walmartlabs.lacinia.executor$invoke_resolver_for_field.invoke(executor.clj:68)",
          "com.walmartlabs.lacinia.executor$resolve_and_select.invokeStatic(executor.clj:353)",
          "com.walmartlabs.lacinia.executor$resolve_and_select.invoke(executor.clj:234)",
          "com.walmartlabs.lacinia.executor$apply_field_selection.invokeStatic(executor.clj:140)",
          "com.walmartlabs.lacinia.executor$apply_field_selection.invoke(executor.clj:135)",
          "com.walmartlabs.lacinia.executor$apply_selection.invokeStatic(executor.clj:173)",
          "com.walmartlabs.lacinia.executor$apply_selection.invoke(executor.clj:165)",
          "com.walmartlabs.lacinia.executor$execute_nested_selections$fn__27193.invoke(executor.clj:197)",
          "com.walmartlabs.lacinia.internal_utils$keepv$fn__23428.invoke(internal_utils.clj:46)",
          "clojure.lang.ArrayChunk.reduce(ArrayChunk.java:58)",
          "clojure.core.protocols$fn__8244.invokeStatic(protocols.clj:136)",
          "clojure.core.protocols$fn__8244.invoke(protocols.clj:124)",
          "clojure.core.protocols$fn__8204$G__8199__8213.invoke(protocols.clj:19)",
          "clojure.core.protocols$seq_reduce.invokeStatic(protocols.clj:31)",
          "clojure.core.protocols$fn__8236.invokeStatic(protocols.clj:75)",
          "clojure.core.protocols$fn__8236.invoke(protocols.clj:75)",
          "clojure.core.protocols$fn__8178$G__8173__8191.invoke(protocols.clj:13)",
          "clojure.core$reduce.invokeStatic(core.clj:6886)",
          "clojure.core$reduce.invoke(core.clj:6868)",
          "com.walmartlabs.lacinia.internal_utils$keepv.invokeStatic(internal_utils.clj:45)",
          "com.walmartlabs.lacinia.internal_utils$keepv.invoke(internal_utils.clj:41)",
          "com.walmartlabs.lacinia.executor$execute_nested_selections.invokeStatic(executor.clj:197)",
          "com.walmartlabs.lacinia.executor$execute_nested_selections.invoke(executor.clj:190)",
          "com.walmartlabs.lacinia.executor$execute_query$fn__27231.invoke(executor.clj:400)",
          "clojure.lang.AFn.applyToHelper(AFn.java:152)",
          "clojure.lang.AFn.applyTo(AFn.java:144)",
          "clojure.core$apply.invokeStatic(core.clj:667)",
          "clojure.core$with_bindings_STAR_.invokeStatic(core.clj:1990)",
          "clojure.core$with_bindings_STAR_.doInvoke(core.clj:1990)",
          "clojure.lang.RestFn.invoke(RestFn.java:425)",
          "clojure.lang.AFn.applyToHelper(AFn.java:156)",
          "clojure.lang.RestFn.applyTo(RestFn.java:132)",
          "clojure.core$apply.invokeStatic(core.clj:671)",
          "clojure.core$bound_fn_STAR_$fn__5818.doInvoke(core.clj:2020)",
          "clojure.lang.RestFn.invoke(RestFn.java:397)",
          "com.walmartlabs.lacinia.executor$execute_query$fn__27236.invoke(executor.clj:421)",
          "clojure.core$binding_conveyor_fn$fn__5823.invoke(core.clj:2047)",
          "clojure.lang.AFn.call(AFn.java:18)",
          "java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)",
          "java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)",
          "java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)",
          "java.base/java.lang.Thread.run(Thread.java:833)"
        ]
      }
    }
  ]
}
```