### PR TITLE
medley 의존성 제거

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -8,7 +8,6 @@
            io.github.hlship/trace              {:git/url "https://github.com/jungwookim/trace"
                                                 :git/sha "27e0faf04fa865d902730da9b944053445f0be7d"}
            io.sentry/sentry-clj                {:mvn/version "5.7.180"}
-           medley/medley                       {:mvn/version "1.4.0"}
            org.clojure/clojure                 {:mvn/version "1.11.1"}
            org.clojure/tools.logging           {:mvn/version "1.2.4"}
            org.clojure/core.match              {:mvn/version "1.0.0"}

--- a/src/gosura/core.clj
+++ b/src/gosura/core.clj
@@ -19,10 +19,10 @@
             [gosura.schema :as schema]
             [gosura.util :as util :refer [transform-keys->camelCaseKeyword
                                           transform-keys->kebab-case-keyword
-                                          requiring-var!]]
+                                          requiring-var!
+                                          update-existing]]
             [malli.core :as m]
-            [malli.error :as me]
-            [medley.core :as medley]))
+            [malli.error :as me]))
 
 (defn- ->kebab-case
   [kebab-case? args parent]
@@ -48,12 +48,12 @@
   [params]
   (-> params
       auth-symbol->requiring-var!
-      (medley/update-existing :table-fetcher requiring-var!)
-      (medley/update-existing :pre-process-arguments requiring-var!)
-      (medley/update-existing :post-process-row requiring-var!)
-      (medley/update-existing :superfetcher requiring-var!)
-      (medley/update-existing :mutation-fn requiring-var!)
-      (medley/update-existing :fetch-one requiring-var!)))
+      (update-existing :table-fetcher requiring-var!)
+      (update-existing :pre-process-arguments requiring-var!)
+      (update-existing :post-process-row requiring-var!)
+      (update-existing :superfetcher requiring-var!)
+      (update-existing :mutation-fn requiring-var!)
+      (update-existing :fetch-one requiring-var!)))
 
 (defn find-resolver-fn
   "resolver-key 에 따라 적절한 resolver-fn 함수를 리턴한다.

--- a/src/gosura/helpers/resolver.clj
+++ b/src/gosura/helpers/resolver.clj
@@ -22,8 +22,8 @@
             [gosura.helpers.superlifter :refer [with-superlifter]]
             [gosura.util :as util :refer [transform-keys->camelCaseKeyword
                                           transform-keys->kebab-case-keyword
-                                          update-resolver-result]]
-            [medley.core :as medley]
+                                          update-resolver-result
+                                          update-existing]]
             [promesa.core :as prom]
             [superlifter.api :as superlifter-api]))
 
@@ -136,14 +136,14 @@
   "인자 맵의 ID들(열이 ids, 그리고 -ids로 끝나는 것들)의 값을 글로벌 ID에서 ID로 디코드한다."
   [arguments]
   (-> arguments
-      (medley/update-existing :ids #(map relay/decode-global-id->db-id %))
+      (update-existing :ids #(map relay/decode-global-id->db-id %))
       (decode-value-in-args "-ids" #(map relay/decode-global-id->db-id %))))
 
 (defn decode-global-id-in-arguments
   "인자 맵의 ID들(열이 id, 그리고 -id로 끝나는 것들)의 값을 글로벌 ID에서 ID로 디코드한다."
   [arguments]
   (-> arguments
-      (medley/update-existing :id relay/decode-global-id->db-id)
+      (update-existing :id relay/decode-global-id->db-id)
       (decode-value-in-args "-id" relay/decode-global-id->db-id)))
 
 (defn common-pre-process-arguments

--- a/src/gosura/util.clj
+++ b/src/gosura/util.clj
@@ -53,6 +53,18 @@
   [m ks f]
   (reduce #(update %1 %2 f) m ks))
 
+(defn update-existing
+  ([m k f]
+   (if-let [kv (find m k)] (assoc m k (f (val kv))) m))
+  ([m k f x]
+   (if-let [kv (find m k)] (assoc m k (f (val kv) x)) m))
+  ([m k f x y]
+   (if-let [kv (find m k)] (assoc m k (f (val kv) x y)) m))
+  ([m k f x y z]
+   (if-let [kv (find m k)] (assoc m k (f (val kv) x y z)) m))
+  ([m k f x y z & more]
+   (if-let [kv (find m k)] (assoc m k (apply f (val kv) x y z more)) m)))
+
 (defn stringify-ids
   "행의 ID들(열이 id, 그리고 -id로 끝나는 것들)을 문자열로 변경한다."
   [row]


### PR DESCRIPTION
deps 알고리즘은 이행적 의존성에 대해 기본적으로 newer 를 취합니다.
https://clojure.org/reference/dep_expansion#_dep_selection

따라서 라이브러리 의존성의 최신화는 보다 더 주의를 해야 하고, 보다 좋은 것은 의존성을 만들지 않는 것입니다.
그런 의미에서 아예 medley 를 없앱니다.