### PR TITLE
decode-id 에 잘못된 id 값이 들어왔을 때 nil을 반환

### DIFF
--- a/src/gosura/helpers/relay.clj
+++ b/src/gosura/helpers/relay.clj
@@ -28,15 +28,14 @@
    \"bm90aWNlLTI=\" -> {:node-type \"notice\", :db-id \"2\"}
    주의: decode된 db id는 string임."
   [id]
-  (when-not (string? id)
-    (throw (ex-info "node id must be string" {:invalid-id id})))
-  (let [[_ node-type db-id] (re-matches #"^(.*):(.*)$"
-                                        (String. (.decode (Base64/getDecoder) id)))
+  (when-not (string? id) nil)
+  (let [decoded (try (String. (.decode (Base64/getDecoder) id))
+                     (catch IllegalArgumentException _ ""))
+        [_ node-type db-id] (re-matches #"^(.*):(.*)$" decoded)
         decoded-result {:node-type (keyword node-type)
                         :db-id db-id}]
-    (when-not (m/validate gosura-schema/decoded-id-schema decoded-result)
-      (throw (ex-info "Invalid node id" {:decoded-id decoded-result})))
-    decoded-result))
+    (when (m/validate gosura-schema/decoded-id-schema decoded-result)
+      decoded-result)))
 
 (defn decode-global-id->db-id [global-id]
   (some-> global-id decode-id :db-id))

--- a/test/gosura/helpers/relay_test.clj
+++ b/test/gosura/helpers/relay_test.clj
@@ -14,12 +14,12 @@
           expected-result {:node-type :test
                            :db-id     "1"}]
       (is (= result expected-result))))
-  (testing "Base64 인코딩된 값이 Node가 아닐 때, 에러를 잘 뱉어낸다"
-    (let [encoded-id "+/ss"]
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid node id" (gosura-relay/decode-id encoded-id)))))
-  (testing "str이 아닌 타입이 입력되었을 때, 에러를 잘 뱉어낸다"
+  (testing "Base64 인코딩된 값이 Node가 아닐 때, nil을 반환한다"
+    (let [encoded-id ".+/ss"]
+      (is nil? (gosura-relay/decode-id encoded-id))))
+  (testing "str이 아닌 타입이 입력되었을 때, nil을 반환한다"
     (let [encoded-id 1]
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"node id must be string" (gosura-relay/decode-id encoded-id))))))
+      (is nil? (gosura-relay/decode-id encoded-id)))))
 
 (deftest encode-node-id-test
   (testing "encode-node-id에 전달되는 값은 map이어야 한다"

--- a/test/gosura/helpers/resolver_test.clj
+++ b/test/gosura/helpers/resolver_test.clj
@@ -205,14 +205,27 @@
           result (test-resolver-6 ctx arg parent)]
       (is (= (-> result
                  :arg) {:testCol "1"}))))
+  (testing "잘못된 형식의 id가 입력되었을 때 decode-ids-by-keys가 nil을 넘겨준다"
+    (let [_      (gosura-resolver2/defresolver test-resolver-7
+                   {:decode-ids-by-keys [:test-col]}
+                   [ctx arg parent]
+                   {:ctx    ctx
+                    :arg    arg
+                    :parent parent})
+          ctx    {}
+          arg    {:test-col ".."}
+          parent {}
+          result (test-resolver-7 ctx arg parent)]
+      (is (= (-> result
+                 :arg) {:testCol nil}))))
   (testing "에러가 던져졌을 때 GraphQL errors를 반환한다"
-    (let [_            (gosura-resolver2/defresolver test-resolver-7
+    (let [_            (gosura-resolver2/defresolver test-resolver-8
                          [_ctx _arg _parent]
                          (throw (ex-info "something wrong!" {})))
           ctx    {}
           arg    {}
           parent {}
-          resolved (test-resolver-7 ctx arg parent)
+          resolved (test-resolver-8 ctx arg parent)
           message (get-in resolved [:resolved-value :data :message])
           info (get-in resolved [:resolved-value :data :info])
           type' (get-in resolved [:resolved-value :data :type])
@@ -223,14 +236,14 @@
         (some? type') true
         (some? stacktrace) true)))
   (testing "catch-exceptions? 설정이 false일 때 에러가 던져지면 그대로 throw한다"
-    (let [_            (gosura-resolver2/defresolver test-resolver-8
+    (let [_            (gosura-resolver2/defresolver test-resolver-9
                          {:catch-exceptions? false}
                          [_ctx _arg _parent]
                          (throw (ex-info "something wrong!" {})))
           ctx    {}
           arg    {}
           parent {}]
-      (is (thrown? ExceptionInfo (test-resolver-8 ctx arg parent))))))
+      (is (thrown? ExceptionInfo (test-resolver-9 ctx arg parent))))))
 
 (comment
   (run-tests))


### PR DESCRIPTION
뮤테이션에서 입력이 잘못된 경우 union 에러를 반환하는 것이 ADR 임에도 `decode-ids-by-keys` 중에 exception이 발생하여 `InvalidInputError`을 반환할 수 없습니다. 따라서 decode-id 에 잘못된 id 값이 들어왔을 때 `nil`을 반환하도록 변경합니다.

신선하이 코드에는 별도의 `decode-id` 구현을 사용하고 있어서 문제가 없을것 같습니다.
https://github.com/green-labs/sinsunhi-backend/blob/a31ef72386ca4d35733a45efeb5598850cdb9352/server/src/sinsun_market/graphql/relay/node.clj#L22