### PR TITLE
BIGINT db-id 지원

### DIFF
--- a/src/gosura/schema.clj
+++ b/src/gosura/schema.clj
@@ -71,7 +71,7 @@
 (def node-schema
   [:map
    [:node-type keyword?]
-   [:db-id [:or string? int?]]])
+   [:db-id [:or string? integer?]]])
 
 (def decoded-id-schema
   [:map

--- a/src/gosura/schema.clj
+++ b/src/gosura/schema.clj
@@ -77,3 +77,11 @@
   [:map
    [:node-type keyword?]
    [:db-id string?]])
+
+(comment
+  (require '[malli.core :as malli])
+  @(def big-integer-db-id (biginteger 1004))
+  (instance? java.math.BigInteger big-integer-db-id)  ;; => true
+  (malli/validate node-schema {:node-type :some-type :db-id big-integer-db-id})
+  (malli/validate node-schema {:node-type :some-type :db-id 1004})
+  (malli/validate node-schema {:node-type :some-type :db-id "1004"}))

--- a/test/gosura/helpers/relay_test.clj
+++ b/test/gosura/helpers/relay_test.clj
@@ -22,6 +22,13 @@
       (is (nil? (gosura-relay/decode-id encoded-id))))))
 
 (deftest encode-node-id-test
+  (testing "encode-node-id 를 실행하면 node 맵에 :id 키가 추가된다."
+    (let [node {:node-type :test, :db-id 1}]
+      (is (= (gosura-relay/encode-node-id {:node-type :test, :db-id 1})
+             (assoc node :id "dGVzdDox"))))
+    (let [node {:node-type :test, :db-id 1}]
+      (is (= (gosura-relay/encode-node-id {:node-type :test, :db-id (biginteger 1)})
+             (assoc node :id "dGVzdDox")))))
   (testing "encode-node-id에 전달되는 값은 map이어야 한다"
     (let [data "data"]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid node schema" (gosura-relay/encode-node-id data)))))


### PR DESCRIPTION
global node id 생성시에 :db-id가 int? 인지 검사하고 있다.
int? 는 타입 검사라서 int 타입이 아니면 거짓으로 판정한다.
MySQL DB에서 id 칼럼의 타입을 BIGINT로 설정한 경우 클로저에서는
java.math.BigInteger 타입으로 입력된다.
그래서 int? 검사에 실패하게 된다.
int? 를 논리적 정수 검사 함수인 integer? 로 변경한다.