### PR TITLE
return-camel-case? 및 parent kebab-case? 케이스 변환 제거

### DIFF
--- a/API.md
+++ b/API.md
@@ -660,7 +660,7 @@ lacinia 용 resolver 함수를 만듭니다.
 
   가능한 설정
   :auth - 인증함수를 넣습니다. gosura.auth의 설명을 참고해주세요.
-  :kebab-case? - arg/parent 의 key를 kebab-case로 변환할지 설정합니다. (기본값 true)
+  :kebab-case? - arg 의 key를 kebab-case로 변환할지 설정합니다. (기본값 true)
   :node-type - relay resolver 일때 설정하면, edge/node와 :pageInfo의 start/endCursor 처리를 같이 해줍니다.
   :required-keys-in-parent - 부모(hash-map)로부터 필요한 required keys를 설정합니다.
 <br><sub>[source](https://github.com/green-labs/gosura/blob/master/src/gosura/helpers/resolver.clj#L81-L106)</sub>
@@ -948,7 +948,7 @@ lacinia 용 resolver 함수를 만듭니다.
 
   가능한 설정
   :auth - 인증함수를 넣습니다. gosura.auth의 설명을 참고해주세요.
-  :kebab-case? - arg/parent 의 key를 kebab-case로 변환할지 설정합니다. (기본값 true)
+  :kebab-case? - arg 의 key를 kebab-case로 변환할지 설정합니다. (기본값 true)
   :required-keys-in-parent - 부모(hash-map)로부터 필요한 required keys를 설정합니다.
   :filters - 특정 필터 로직을 넣습니다
 <br><sub>[source](https://github.com/green-labs/gosura/blob/master/src/gosura/helpers/resolver2.clj#L52-L77)</sub>
@@ -967,7 +967,7 @@ GraphQL 리졸버가 공통으로 해야 할 auth 처리, case 변환 처리를 
   this, ctx, arg, parent: 상위 리졸버 생성 매크로에서 만든 심벌
   option: 리졸버 선언에 지정된 옵션 맵
    - :auth - 인증함수를 넣습니다. gosura.auth의 설명을 참고해주세요.
-   - :kebab-case? - arg/parent 의 key를 kebab-case로 변환할지 설정합니다. (기본값 true)
+   - :kebab-case? - arg 의 key를 kebab-case로 변환할지 설정합니다. (기본값 true)
    - :required-keys-in-parent - 부모(hash-map)로부터 필요한 required keys를 설정합니다.
    - :decode-ids-by-keys - 키 목록을 받아서 resolver args의 global id들을 db id로 변환 해줍니다.
    - :filters - args에 추가할 key-value 값을 필터로 넣습니다.

--- a/API.md
+++ b/API.md
@@ -662,7 +662,6 @@ lacinia 용 resolver 함수를 만듭니다.
   :auth - 인증함수를 넣습니다. gosura.auth의 설명을 참고해주세요.
   :kebab-case? - arg/parent 의 key를 kebab-case로 변환할지 설정합니다. (기본값 true)
   :node-type - relay resolver 일때 설정하면, edge/node와 :pageInfo의 start/endCursor 처리를 같이 해줍니다.
-  :return-camel-case? - 반환값을 camelCase 로 변환할지 설정합니다. (기본값 true)
   :required-keys-in-parent - 부모(hash-map)로부터 필요한 required keys를 설정합니다.
 <br><sub>[source](https://github.com/green-labs/gosura/blob/master/src/gosura/helpers/resolver.clj#L81-L106)</sub>
 ## `keys-not-found`
@@ -950,7 +949,6 @@ lacinia 용 resolver 함수를 만듭니다.
   가능한 설정
   :auth - 인증함수를 넣습니다. gosura.auth의 설명을 참고해주세요.
   :kebab-case? - arg/parent 의 key를 kebab-case로 변환할지 설정합니다. (기본값 true)
-  :return-camel-case? - 반환값을 camelCase 로 변환할지 설정합니다. (기본값 true)
   :required-keys-in-parent - 부모(hash-map)로부터 필요한 required keys를 설정합니다.
   :filters - 특정 필터 로직을 넣습니다
 <br><sub>[source](https://github.com/green-labs/gosura/blob/master/src/gosura/helpers/resolver2.clj#L52-L77)</sub>
@@ -970,7 +968,6 @@ GraphQL 리졸버가 공통으로 해야 할 auth 처리, case 변환 처리를 
   option: 리졸버 선언에 지정된 옵션 맵
    - :auth - 인증함수를 넣습니다. gosura.auth의 설명을 참고해주세요.
    - :kebab-case? - arg/parent 의 key를 kebab-case로 변환할지 설정합니다. (기본값 true)
-   - :return-camel-case? - 반환값을 camelCase 로 변환할지 설정합니다. (기본값 true)
    - :required-keys-in-parent - 부모(hash-map)로부터 필요한 required keys를 설정합니다.
    - :decode-ids-by-keys - 키 목록을 받아서 resolver args의 global id들을 db id로 변환 해줍니다.
    - :filters - args에 추가할 key-value 값을 필터로 넣습니다.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Below is the list of a full configuration.
                          :resolve-connection {:table-fetcher #var animal.db/fetch
                                               :settings      {:auth               #var animal.core/auth ; set for authentification and authorization.
                                                               :kebab-case?        true ; opts ; transform args into kebeb-case. A default is true.
-                                                              :return-camel-case? true}} ; opts ; transform results into camelCase. A default value is true.
+                                                              }}
                          :resolve-by-fk      {:superfetcher #var animal.superfetcher/->Fetch ; superfetcher for superlifter
                                               :fk-in-parent :user-type-id}
                          :resolve-create-one {:table-fetcher #var animal.db/fetch

--- a/deps.edn
+++ b/deps.edn
@@ -5,6 +5,7 @@
            com.taoensso/nippy                  {:mvn/version "3.2.0"}
            com.walmartlabs/lacinia             {:mvn/version "1.1"}
            com.taoensso/timbre                 {:mvn/version "6.0.2"}
+           com.google.guava/guava              {:mvn/version "31.1-jre"}
            failjure/failjure                   {:mvn/version "2.2.0"}
            io.github.hlship/trace              {:git/url "https://github.com/jungwookim/trace"
                                                 :git/sha "27e0faf04fa865d902730da9b944053445f0be7d"}

--- a/src/gosura/core.clj
+++ b/src/gosura/core.clj
@@ -17,20 +17,11 @@
             [gosura.helpers.resolver :as r]
             [gosura.helpers.resolver2 :as r2]
             [gosura.schema :as schema]
-            [gosura.util :as util :refer [transform-keys->camelCaseKeyword
-                                          transform-keys->kebab-case-keyword
-                                          requiring-var!
-                                          update-existing]]
+            [gosura.util :as util :refer [requiring-var!
+                                          transform-keys->camelCaseKeyword
+                                          transform-keys->kebab-case-keyword update-existing]]
             [malli.core :as m]
             [malli.error :as me]))
-
-(defn- ->kebab-case
-  [kebab-case? args parent]
-  (if kebab-case?
-    {:args   (transform-keys->kebab-case-keyword args)
-     :parent (transform-keys->kebab-case-keyword parent)}
-    {:args   args
-     :parent parent}))
 
 (defn-
   ^{:deprecated "0.2.8"}
@@ -147,7 +138,7 @@
                                                            kebab-case?
                                                            return-camel-case?]
                                                     :or   {kebab-case? true}} settings
-                                                   {:keys [args parent]} (->kebab-case kebab-case? args parent)
+                                                   args' (if kebab-case? (transform-keys->kebab-case-keyword args) args)
                                                    auth-filter-opts (auth/->auth-result auth ctx)
                                                    config-filter-opts (auth/config-filter-opts filters ctx)
                                                    resolver-filter-opts (auth/config-filter-opts (:filters params) ctx)
@@ -159,7 +150,7 @@
                                                    added-params (merge params {:additional-filter-opts (merge auth-filter-opts
                                                                                                               config-filter-opts
                                                                                                               resolver-filter-opts)})]
-                                                  (cond-> (resolver-fn ctx args parent added-params)
+                                                  (cond-> (resolver-fn ctx args' parent added-params)
                                                     return-camel-case? (util/update-resolver-result transform-keys->camelCaseKeyword))
                                                   (f/when-failed [e]
                                                     (log/error e)

--- a/src/gosura/core.clj
+++ b/src/gosura/core.clj
@@ -135,8 +135,7 @@
           (intern target-ns (symbol resolver) (fn [ctx args parent]
                                                 (f/attempt-all
                                                   [{:keys [auth
-                                                           kebab-case?
-                                                           return-camel-case?]
+                                                           kebab-case?]
                                                     :or   {kebab-case? true}} settings
                                                    args' (if kebab-case? (transform-keys->kebab-case-keyword args) args)
                                                    auth-filter-opts (auth/->auth-result auth ctx)
@@ -150,8 +149,7 @@
                                                    added-params (merge params {:additional-filter-opts (merge auth-filter-opts
                                                                                                               config-filter-opts
                                                                                                               resolver-filter-opts)})]
-                                                  (cond-> (resolver-fn ctx args' parent added-params)
-                                                    return-camel-case? (util/update-resolver-result transform-keys->camelCaseKeyword))
+                                                  (resolver-fn ctx args' parent added-params)
                                                   (f/when-failed [e]
                                                     (log/error e)
                                                     (resolve-as nil {:resolver (format "%s/%s" (str target-ns) (name resolver))

--- a/src/gosura/core.clj
+++ b/src/gosura/core.clj
@@ -18,7 +18,6 @@
             [gosura.helpers.resolver2 :as r2]
             [gosura.schema :as schema]
             [gosura.util :as util :refer [requiring-var!
-                                          transform-keys->camelCaseKeyword
                                           transform-keys->kebab-case-keyword update-existing]]
             [malli.core :as m]
             [malli.error :as me]))

--- a/src/gosura/helpers/case_format.clj
+++ b/src/gosura/helpers/case_format.clj
@@ -1,0 +1,84 @@
+(ns gosura.helpers.case-format
+  (:require [clojure.walk :as walk])
+  (:import [clojure.lang Keyword]
+           [com.google.common.base CaseFormat]))
+
+(def camelCase ^CaseFormat CaseFormat/LOWER_CAMEL)
+(def PascalCase ^CaseFormat CaseFormat/UPPER_CAMEL)
+(def kebab-case ^CaseFormat CaseFormat/LOWER_HYPHEN)
+(def snake_case ^CaseFormat CaseFormat/LOWER_UNDERSCORE)
+(def UPPER_SNAKE_CASE ^CaseFormat CaseFormat/UPPER_UNDERSCORE)
+
+(defn transform
+  "문자열 s를 CaseFormat from 에서 CaseFormat to 형식의 문자열로 변환합니다.
+   사용 가능한 CaseFormat: cf/camelCase, cf/PascalCase cf/kebab-case cf/snake_case cf/UPPER_SNAKE_CASE"
+  ^String [^CaseFormat from ^CaseFormat to ^String s]
+  (.to from to s))
+
+(defn transform-keyword
+  "키워드 k를 CaseFormat from 에서 CaseFormat to 형식의 문자열로 변환합니다.
+   사용 가능한 CaseFormat: cf/camelCase, cf/PascalCase cf/kebab-case cf/snake_case cf/UPPER_SNAKE_CASE"
+  ^Keyword [^CaseFormat from ^CaseFormat to ^Keyword k]
+  (keyword (transform from to (name k))))
+
+(defn camelCase->kebab-case ^String [^String s]
+  (transform camelCase kebab-case s))
+
+(defn camelCaseKeyword->kebab-case-keyword ^Keyword [^Keyword k]
+  (keyword (camelCase->kebab-case (name k))))
+
+(defn kebab-case->camelCase ^String [^String s]
+  (transform kebab-case camelCase s))
+
+(defn kebab-case-keyword->camelCaseKeyowrd ^Keyword [^Keyword k]
+  (keyword (kebab-case->camelCase (name k))))
+
+(defn snake_case->kebab-case ^String [^String s]
+  (transform snake_case kebab-case s))
+
+(defn snake_case_keyword->kebab-case-keyword ^Keyword [^Keyword k]
+  (keyword (snake_case->kebab-case (name k))))
+
+(defn kebab-case->snake_case ^String [^String s]
+  (transform kebab-case snake_case s))
+
+(defn kebab-case-keyword->snake_case_keyword ^Keyword [^Keyword k]
+  (keyword (kebab-case->snake_case (name k))))
+
+(defn kebab-case->PascalCase ^String [^String s]
+  (transform kebab-case PascalCase s))
+
+(defn kebab-case-keyword->PascalCaseKeyword ^Keyword [^Keyword k]
+  (keyword (kebab-case->PascalCase (name k))))
+
+(defn UPPER_SNAKE_CASE->kebab-case ^String [^String s]
+  (transform UPPER_SNAKE_CASE kebab-case s))
+
+(defn UPPER_SNAKE_CASE_KEYWORD->kebab-case-keyword ^Keyword [^Keyword k]
+  (keyword (UPPER_SNAKE_CASE->kebab-case (name k))))
+
+(defn transform-keys
+  "재귀적으로 컬랙션의 모든 키를 변환합니다."
+  [t coll]
+  (letfn [(transform [[k v]] [(t k) v])]
+    (walk/postwalk (fn [x] (if (map? x) (with-meta (into {} (map transform x)) (meta x)) x)) coll)))
+
+(defn transform-keys-camelCase->kebab-case
+  "재귀적으로 컬랙션의 모든 키를 camelCase->kebab-case 변환합니다."
+  [m]
+  (transform-keys camelCaseKeyword->kebab-case-keyword m))
+
+(defn transform-keys-kebab-case->camelCase
+  "재귀적으로 컬랙션의 모든 키를 kebab-case->camelCase 변환합니다."
+  [m]
+  (transform-keys kebab-case-keyword->camelCaseKeyowrd m))
+
+(defn transform-keys-snake_case->kebab-case
+  "재귀적으로 컬랙션의 모든 키를 snake_case->kebab-case 변환합니다."
+  [m]
+  (transform-keys snake_case_keyword->kebab-case-keyword m))
+
+(defn transform-keys-kebab-case->snake_case
+  "재귀적으로 컬랙션의 모든 키를 kebab-case->snake_case 변환합니다."
+  [m]
+  (transform-keys kebab-case-keyword->snake_case_keyword m))

--- a/src/gosura/helpers/db.clj
+++ b/src/gosura/helpers/db.clj
@@ -10,7 +10,7 @@
 
 (def ^:private col-with-table-name-pattern #"[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*")
 
-(defn- as-unqualified-kebab-maps
+(defn as-unqualified-kebab-maps
   [rs opts]
   (as-unqualified-modified-maps rs (assoc opts :label-fn cf/snake_case->kebab-case)))
 

--- a/src/gosura/helpers/db.clj
+++ b/src/gosura/helpers/db.clj
@@ -1,13 +1,18 @@
 (ns gosura.helpers.db
   (:require [clojure.set]
             [clojure.string]
+            [gosura.helpers.case-format :as cf]
             [honey.sql :as honeysql]
             [honey.sql.helpers :as sql-helper]
             [net.lewisship.trace :refer [trace]]
             [next.jdbc :as jdbc]
-            [next.jdbc.result-set :as rs]))
+            [next.jdbc.result-set :as rs :refer [as-unqualified-modified-maps]]))
 
 (def ^:private col-with-table-name-pattern #"[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*")
+
+(defn- as-unqualified-kebab-maps
+  [rs opts]
+  (as-unqualified-modified-maps rs (assoc opts :label-fn cf/snake_case->kebab-case)))
 
 (defn col-with-table-name?
   [col-name]
@@ -228,23 +233,41 @@
 
 (defn unqualified-kebab-fetch!
   [ds qs]
-  (fetch! ds qs {:builder-fn rs/as-unqualified-kebab-maps}))
+  (fetch! ds qs {:builder-fn   as-unqualified-kebab-maps
+                 :column-fn    cf/kebab-case-keyword->snake_case_keyword
+                 :table-fn     cf/kebab-case-keyword->snake_case_keyword
+                 :label-fn     cf/snake_case_keyword->kebab-case-keyword
+                 :qualifier-fn cf/snake_case_keyword->kebab-case-keyword}))
 
 (defmacro unqualified-kebab-fetch2!
   [ds qs]
   `(let [sql# (honeysql/format ~qs honey-sql-format-options)]
      (trace :sql (format-query sql#))
-     (jdbc/execute! ~ds sql# (merge {:timeout query-timeout} {:builder-fn rs/as-unqualified-kebab-maps}))))
+     (jdbc/execute! ~ds sql# (merge {:timeout query-timeout}
+                                    {:builder-fn   as-unqualified-kebab-maps
+                                     :column-fn    cf/kebab-case-keyword->snake_case_keyword
+                                     :table-fn     cf/kebab-case-keyword->snake_case_keyword
+                                     :label-fn     cf/snake_case_keyword->kebab-case-keyword
+                                     :qualifier-fn cf/snake_case_keyword->kebab-case-keyword}))))
 
 (defn unqualified-kebab-fetch-one!
   [ds qs]
-  (fetch-one! ds qs {:builder-fn rs/as-unqualified-kebab-maps}))
+  (fetch-one! ds qs {:builder-fn   as-unqualified-kebab-maps
+                     :column-fn    cf/kebab-case-keyword->snake_case_keyword
+                     :table-fn     cf/kebab-case-keyword->snake_case_keyword
+                     :label-fn     cf/snake_case_keyword->kebab-case-keyword
+                     :qualifier-fn cf/snake_case_keyword->kebab-case-keyword}))
 
 (defmacro unqualified-kebab-fetch-one2!
   [ds qs]
   `(let [sql# (honeysql/format (sql-helper/limit ~qs 1) honey-sql-format-options)]
      (trace :sql (format-query sql#))
-     (jdbc/execute-one! ~ds sql# (merge {:timeout query-timeout} {:builder-fn rs/as-unqualified-kebab-maps}))))
+     (jdbc/execute-one! ~ds sql# (merge {:timeout query-timeout}
+                                        {:builder-fn   as-unqualified-kebab-maps
+                                         :column-fn    cf/kebab-case-keyword->snake_case_keyword
+                                         :table-fn     cf/kebab-case-keyword->snake_case_keyword
+                                         :label-fn     cf/snake_case_keyword->kebab-case-keyword
+                                         :qualifier-fn cf/snake_case_keyword->kebab-case-keyword}))))
 
 (defn insert-one
   "db

--- a/src/gosura/helpers/resolver.clj
+++ b/src/gosura/helpers/resolver.clj
@@ -48,9 +48,8 @@
         result (gensym 'result_)
         authorized? `(auth/apply-fn-with-ctx-at-first ~auth ~ctx)
         arg' (if kebab-case? `(transform-keys->kebab-case-keyword ~arg) arg)
-        parent' (if kebab-case? `(transform-keys->kebab-case-keyword ~parent) parent)
-        keys-not-found `(keys-not-found ~parent' ~required-keys-in-parent)
-        params (if (nil? this) [ctx arg' parent'] [this ctx arg' parent'])
+        keys-not-found `(keys-not-found ~parent ~required-keys-in-parent)
+        params (if (nil? this) [ctx arg' parent] [this ctx arg' parent])
         let-mapping (vec (interleave args params))]
 
     `(if (seq ~keys-not-found)
@@ -90,7 +89,7 @@
 
   가능한 설정
   :auth - 인증함수를 넣습니다. gosura.auth의 설명을 참고해주세요.
-  :kebab-case? - arg/parent 의 key를 kebab-case로 변환할지 설정합니다. (기본값 true)
+  :kebab-case? - arg 의 key를 kebab-case로 변환할지 설정합니다. (기본값 true)
   :node-type - relay resolver 일때 설정하면, edge/node와 :pageInfo의 start/endCursor 처리를 같이 해줍니다.
   :required-keys-in-parent - 부모(hash-map)로부터 필요한 required keys를 설정합니다."
   {:arglists '([name doc-string? option? args & body])}

--- a/src/gosura/helpers/resolver.clj
+++ b/src/gosura/helpers/resolver.clj
@@ -22,7 +22,6 @@
             [gosura.helpers.superlifter :refer [with-superlifter]]
             [gosura.util :as util :refer [transform-keys->camelCaseKeyword
                                           transform-keys->kebab-case-keyword
-                                          update-resolver-result
                                           update-existing]]
             [promesa.core :as prom]
             [superlifter.api :as superlifter-api]))

--- a/src/gosura/helpers/resolver.clj
+++ b/src/gosura/helpers/resolver.clj
@@ -41,9 +41,8 @@
   args: 리졸버 선언의 argument vector 부분
   body: 리졸버의 body expression 부분"
   [{:keys [this ctx arg parent]} option args body]
-  (let [{:keys [auth kebab-case? return-camel-case? required-keys-in-parent]
+  (let [{:keys [auth kebab-case? required-keys-in-parent]
          :or   {kebab-case?             true
-                return-camel-case?      true
                 required-keys-in-parent []}} option
 
         result (gensym 'result_)
@@ -58,8 +57,7 @@
        (error/error {:message (format "%s keys are needed in parent" ~keys-not-found)})
        (if ~authorized?
          (let [~result (do (let ~let-mapping ~@body))]
-           (cond-> ~result
-                   ~return-camel-case? (update-resolver-result transform-keys->camelCaseKeyword)))
+           ~result)
          (resolve-as nil {:message "Unauthorized"})))))
 
 (defn parse-fdecl
@@ -94,7 +92,6 @@
   :auth - 인증함수를 넣습니다. gosura.auth의 설명을 참고해주세요.
   :kebab-case? - arg/parent 의 key를 kebab-case로 변환할지 설정합니다. (기본값 true)
   :node-type - relay resolver 일때 설정하면, edge/node와 :pageInfo의 start/endCursor 처리를 같이 해줍니다.
-  :return-camel-case? - 반환값을 camelCase 로 변환할지 설정합니다. (기본값 true)
   :required-keys-in-parent - 부모(hash-map)로부터 필요한 required keys를 설정합니다."
   {:arglists '([name doc-string? option? args & body])}
   [name & fdecl]
@@ -110,9 +107,7 @@
   [node-type & fdecl]
   (let [{:keys [option args body]} (parse-fdecl fdecl)
         node-type (keyword node-type)
-        node-type-pascal (csk/->PascalCaseKeyword node-type)
-        {:keys [return-camel-case?] :or {return-camel-case? true}} option
-        transform-keys->camelCaseKeyword' (if return-camel-case? transform-keys->camelCaseKeyword identity)]
+        node-type-pascal (csk/->PascalCaseKeyword node-type)]
     `(defmethod relay/node-resolver ~node-type [this# ctx# arg# parent#]
        (let [result# (wrap-resolver-body {:this this#
                                           :ctx ctx#
@@ -120,7 +115,6 @@
                                           :parent parent#} ~option ~args ~body)]
          (-> result#
              (relay/build-node ~node-type)
-             ~transform-keys->camelCaseKeyword'
              (tag-with-type ~node-type-pascal))))))
 
 ;;; Utility functions
@@ -186,22 +180,18 @@
   "
   [context _arguments parent {:keys [db-key node-type superfetcher
                                      post-process-row
-                                     additional-filter-opts
-                                     return-camel-case?]
-                              :or {return-camel-case? true}}]
+                                     additional-filter-opts]}]
   {:pre [(some? db-key)]}
   (let [parent-id (-> parent :id relay/decode-global-id->db-id)
         superfetch-arguments (merge additional-filter-opts
                                     {:id           parent-id
                                      :page-options nil})
-        superfetch-id (hash superfetch-arguments)
-        transform-keys->camelCaseKeyword' (if return-camel-case? transform-keys->camelCaseKeyword identity)]
+        superfetch-id (hash superfetch-arguments)]
     (with-superlifter (:superlifter context)
-                      (-> (superlifter-api/enqueue! db-key (superfetcher superfetch-id superfetch-arguments))
-                          (prom/then (fn [rows]
-                                       (-> (first rows)
-                                           (relay/build-node node-type post-process-row)
-                                           transform-keys->camelCaseKeyword')))))))
+      (-> (superlifter-api/enqueue! db-key (superfetcher superfetch-id superfetch-arguments))
+          (prom/then (fn [rows]
+                       (-> (first rows)
+                           (relay/build-node node-type post-process-row))))))))
 
 (defn resolve-by-fk
   "Lacinia 리졸버로서 config 설정에 따라 단건 조회 쿼리를 처리한다.
@@ -221,9 +211,7 @@
   "
   [context _arguments parent {:keys [db-key node-type superfetcher
                                      post-process-row fk-in-parent
-                                     additional-filter-opts
-                                     return-camel-case?]
-                              :or {return-camel-case? true}}]
+                                     additional-filter-opts]}]
   {:pre [(some? db-key)]}
   (let [fk (get parent fk-in-parent)
         ; TODO: 생각해볼 점: 여기서 fk가 nil이면 아래의 로직을 안 타고 바로 nil을 반환해도 될 것 같음
@@ -231,13 +219,11 @@
         superfetch-arguments (merge additional-filter-opts
                                     {:id           fk
                                      :page-options page-options})
-        superfetch-id (hash superfetch-arguments)
-        transform-keys->camelCaseKeyword' (if return-camel-case? transform-keys->camelCaseKeyword identity)]
+        superfetch-id (hash superfetch-arguments)]
     (with-superlifter (:superlifter context)
-                      (-> (superlifter-api/enqueue! db-key (superfetcher superfetch-id superfetch-arguments))
-                          (prom/then (fn [rows] (-> (first rows)
-                                                    (relay/build-node node-type post-process-row)
-                                                    transform-keys->camelCaseKeyword')))))))
+      (-> (superlifter-api/enqueue! db-key (superfetcher superfetch-id superfetch-arguments))
+          (prom/then (fn [rows] (-> (first rows)
+                                    (relay/build-node node-type post-process-row))))))))
 
 (defn resolve-connection
   "Lacinia 리졸버로서 config 설정에 따라 목록 조회 쿼리를 처리한다.
@@ -262,9 +248,7 @@
                                      table-fetcher
                                      pre-process-arguments
                                      post-process-row
-                                     additional-filter-opts
-                                     return-camel-case?]
-                              :or {return-camel-case? true}}]
+                                     additional-filter-opts]}]
   (let [db (get context db-key)
         arguments (-> arguments
                       common-pre-process-arguments
@@ -275,12 +259,10 @@
                 page-size
                 cursor-id] :as page-options} (relay/build-page-options arguments)
         filter-options (relay/build-filter-options arguments additional-filter-opts)
-        rows (table-fetcher db filter-options page-options)
-        transform-keys->camelCaseKeyword' (if return-camel-case? transform-keys->camelCaseKeyword identity)]
+        rows (table-fetcher db filter-options page-options)]
     (->> rows
          (map #(relay/build-node % node-type post-process-row))
-         (relay/build-connection order-by page-direction page-size cursor-id)
-         transform-keys->camelCaseKeyword')))
+         (relay/build-connection order-by page-direction page-size cursor-id))))
 
 ;; FIXME: N+1 쿼리임
 (defn resolve-connection-by-pk-list
@@ -301,9 +283,7 @@
   "
   [context arguments parent {:keys [db-key node-type table-fetcher pk-list-name
                                     post-process-row pk-list-name-in-parent
-                                    additional-filter-opts
-                                    return-camel-case?]
-                             :or {return-camel-case? true}}]
+                                    additional-filter-opts]}]
   {:pre [(some? db-key)]}
   (let [db (get context db-key)
         arguments (-> arguments
@@ -317,12 +297,10 @@
         pk-list (get parent pk-list-name-in-parent)
         decoded-pk-list (map relay/decode-global-id->db-id pk-list)
         filter-options (relay/build-filter-options (assoc arguments (or pk-list-name :ids) decoded-pk-list) additional-filter-opts)
-        rows (table-fetcher db filter-options page-options)
-        transform-keys->camelCaseKeyword' (if return-camel-case? transform-keys->camelCaseKeyword identity)]
+        rows (table-fetcher db filter-options page-options)]
     (->> rows
          (map #(relay/build-node % node-type post-process-row))
-         (relay/build-connection order-by page-direction page-size cursor-id)
-         transform-keys->camelCaseKeyword')))
+         (relay/build-connection order-by page-direction page-size cursor-id))))
 
 (defn resolve-connection-by-fk
   "Lacinia 리졸버로서 config 설정에 따라 목록 조회 쿼리를 처리한다.
@@ -340,9 +318,7 @@
   "
   [context arguments parent {:keys [db-key node-type superfetcher
                                     post-process-row
-                                    additional-filter-opts
-                                    return-camel-case?]
-                             :or {return-camel-case? true}}]
+                                    additional-filter-opts]}]
   {:pre [(some? db-key)]}
   (let [arguments (-> arguments
                       common-pre-process-arguments
@@ -356,15 +332,13 @@
         superfetch-arguments (merge additional-filter-opts
                                     {:id           parent-id
                                      :page-options page-options})
-        superfetch-id (hash superfetch-arguments)
-        transform-keys->camelCaseKeyword' (if return-camel-case? transform-keys->camelCaseKeyword identity)]
+        superfetch-id (hash superfetch-arguments)]
     (with-superlifter (:superlifter context)
-                      (-> (superlifter-api/enqueue! db-key (superfetcher superfetch-id superfetch-arguments))
-                          (prom/then (fn [rows]
-                                       (->> rows
-                                            (map #(relay/build-node % node-type post-process-row))
-                                            (relay/build-connection order-by page-direction page-size cursor-id)
-                                            transform-keys->camelCaseKeyword')))))))
+      (-> (superlifter-api/enqueue! db-key (superfetcher superfetch-id superfetch-arguments))
+          (prom/then (fn [rows]
+                       (->> rows
+                            (map #(relay/build-node % node-type post-process-row))
+                            (relay/build-connection order-by page-direction page-size cursor-id))))))))
 
 ; TODO 다른 mutation helper 함수와 통합
 (defn pack-mutation-result
@@ -484,18 +458,14 @@
                                      fetch-one
                                      pre-process-arguments
                                      post-process-row
-                                     additional-filter-opts
-                                     return-camel-case?]
+                                     additional-filter-opts]
                               :or {pre-process-arguments identity
-                                   post-process-row identity
-                                   return-camel-case? true}}]
+                                   post-process-row identity}}]
   (let [db             (get context db-key)
         arguments      (-> arguments
                            common-pre-process-arguments
                            pre-process-arguments)
         filter-options (relay/build-filter-options arguments additional-filter-opts)
-        row            (fetch-one db filter-options {})
-        transform-keys->camelCaseKeyword' (if return-camel-case? transform-keys->camelCaseKeyword identity)]
+        row            (fetch-one db filter-options {})]
     (-> (relay/build-node row node-type post-process-row)
-        transform-keys->camelCaseKeyword'
         (tag-with-type (csk/->PascalCaseKeyword node-type)))))

--- a/src/gosura/helpers/resolver2.clj
+++ b/src/gosura/helpers/resolver2.clj
@@ -39,17 +39,15 @@
   option: 리졸버 선언에 지정된 옵션 맵
    - :auth - 인증함수를 넣습니다. gosura.auth의 설명을 참고해주세요.
    - :kebab-case? - arg/parent 의 key를 kebab-case로 변환할지 설정합니다. (기본값 true)
-   - :return-camel-case? - 반환값을 camelCase 로 변환할지 설정합니다. (기본값 true)
    - :catch-exceptions? - 리졸버에서 발생하는 예외를 포착하여 :errors 응답으로 반환 (기본값 true)
    - :required-keys-in-parent - 부모(hash-map)로부터 필요한 required keys를 설정합니다.
    - :decode-ids-by-keys - 키 목록을 받아서 resolver args의 global id들을 db id로 변환 해줍니다.
    - :filters - args에 추가할 key-value 값을 필터로 넣습니다.
   "
   [{:keys [this ctx arg parent]} option args body]
-  (let [{:keys [auth kebab-case? return-camel-case? required-keys-in-parent
+  (let [{:keys [auth kebab-case? required-keys-in-parent
                 filters decode-ids-by-keys catch-exceptions?]
          :or   {kebab-case?             true
-                return-camel-case?      true
                 catch-exceptions?       true
                 required-keys-in-parent []}} option
         result (gensym 'result_)
@@ -68,8 +66,7 @@
                (and ~auth-filter-opts
                     (not (f/failed? ~auth-filter-opts))))
          (let [~result (do (let ~let-mapping (wrap-catch-body ~catch-exceptions? ~body)))]
-           (cond-> ~result
-             ~return-camel-case? (update-resolver-result transform-keys->camelCaseKeyword)))
+           ~result)
          (resolve-as nil {:message "Unauthorized"})))))
 
 
@@ -88,7 +85,6 @@
   가능한 설정
   :auth - 인증함수를 넣습니다. gosura.auth의 설명을 참고해주세요.
   :kebab-case? - arg/parent 의 key를 kebab-case로 변환할지 설정합니다. (기본값 true)
-  :return-camel-case? - 반환값을 camelCase 로 변환할지 설정합니다. (기본값 true)
   :catch-exceptions? - 리졸버에서 발생하는 예외를 포착하여 :errors 응답으로 반환 (기본값 true)
   :required-keys-in-parent - 부모(hash-map)로부터 필요한 required keys를 설정합니다.
   :filters - 특정 필터 로직을 넣습니다"
@@ -123,9 +119,7 @@
                                     superfetcher
                                     parent-id
                                     post-process-row
-                                    additional-filter-opts
-                                    return-camel-case?]
-                             :or {return-camel-case? true}}]
+                                    additional-filter-opts]}]
   {:pre [(some? db-key)]}
   (let [arguments (-> arguments
                       common-pre-process-arguments
@@ -141,15 +135,13 @@
                                     {:id           load-id
                                      :page-options page-options
                                      :agg          agg})
-        superfetch-id (hash superfetch-arguments)
-        transform-keys->camelCaseKeyword' (if return-camel-case? transform-keys->camelCaseKeyword identity)]
+        superfetch-id (hash superfetch-arguments)]
     (with-superlifter (:superlifter context)
       (-> (superlifter-api/enqueue! db-key (superfetcher superfetch-id superfetch-arguments))
           (prom/then (fn [rows]
                        (->> rows
                             (map #(relay/build-node % node-type post-process-row))
-                            (relay/build-connection order-by page-direction page-size cursor-id)
-                            transform-keys->camelCaseKeyword')))))))
+                            (relay/build-connection order-by page-direction page-size cursor-id))))))))
 
 (defn one-by
   "Lacinia 리졸버로서 config 설정에 따라 단건 조회 쿼리를 처리한다.
@@ -173,9 +165,7 @@
                                      superfetcher
                                      post-process-row
                                      parent-id
-                                     additional-filter-opts
-                                     return-camel-case?]
-                              :or {return-camel-case? true}}]
+                                     additional-filter-opts]}]
   {:pre [(some? db-key)]}
   (let [{:keys [pre-fn prop agg]} parent-id
         load-id                   ((or pre-fn identity) (prop parent))
@@ -183,10 +173,8 @@
                                          {:id           load-id
                                           :page-options nil
                                           :agg          agg})
-        superfetch-id             (hash superfetch-arguments)
-        transform-keys->camelCaseKeyword' (if return-camel-case? transform-keys->camelCaseKeyword identity)]
+        superfetch-id             (hash superfetch-arguments)]
     (with-superlifter (:superlifter context)
       (-> (superlifter-api/enqueue! db-key (superfetcher superfetch-id superfetch-arguments))
           (prom/then (fn [rows] (-> (first rows)
-                                    (relay/build-node node-type post-process-row)
-                                    transform-keys->camelCaseKeyword')))))))
+                                    (relay/build-node node-type post-process-row))))))))

--- a/src/gosura/helpers/resolver2.clj
+++ b/src/gosura/helpers/resolver2.clj
@@ -38,7 +38,7 @@
   this, ctx, arg, parent: 상위 리졸버 생성 매크로에서 만든 심벌
   option: 리졸버 선언에 지정된 옵션 맵
    - :auth - 인증함수를 넣습니다. gosura.auth의 설명을 참고해주세요.
-   - :kebab-case? - arg/parent 의 key를 kebab-case로 변환할지 설정합니다. (기본값 true)
+   - :kebab-case? - arg 의 key를 kebab-case로 변환할지 설정합니다. (기본값 true)
    - :catch-exceptions? - 리졸버에서 발생하는 예외를 포착하여 :errors 응답으로 반환 (기본값 true)
    - :required-keys-in-parent - 부모(hash-map)로부터 필요한 required keys를 설정합니다.
    - :decode-ids-by-keys - 키 목록을 받아서 resolver args의 global id들을 db id로 변환 해줍니다.
@@ -56,9 +56,8 @@
         arg `(merge ~arg ~auth-filter-opts ~config-filter-opts)
         arg' (if kebab-case? `(transform-keys->kebab-case-keyword ~arg) arg)
         arg' (if decode-ids-by-keys `(relay/decode-global-ids-by-keys ~arg' ~decode-ids-by-keys) arg')
-        parent' (if kebab-case? `(transform-keys->kebab-case-keyword ~parent) parent)
-        keys-not-found `(keys-not-found ~parent' ~required-keys-in-parent)
-        params (if (nil? this) [ctx arg' parent'] [this ctx arg' parent'])
+        keys-not-found `(keys-not-found ~parent ~required-keys-in-parent)
+        params (if (nil? this) [ctx arg' parent] [this ctx arg' parent])
         let-mapping (vec (interleave args params))]
     `(if (seq ~keys-not-found)
        (error/error {:message (format "%s keys are needed in parent" ~keys-not-found)})
@@ -84,7 +83,7 @@
 
   가능한 설정
   :auth - 인증함수를 넣습니다. gosura.auth의 설명을 참고해주세요.
-  :kebab-case? - arg/parent 의 key를 kebab-case로 변환할지 설정합니다. (기본값 true)
+  :kebab-case? - arg 의 key를 kebab-case로 변환할지 설정합니다. (기본값 true)
   :catch-exceptions? - 리졸버에서 발생하는 예외를 포착하여 :errors 응답으로 반환 (기본값 true)
   :required-keys-in-parent - 부모(hash-map)로부터 필요한 required keys를 설정합니다.
   :filters - 특정 필터 로직을 넣습니다"

--- a/src/gosura/helpers/resolver2.clj
+++ b/src/gosura/helpers/resolver2.clj
@@ -9,9 +9,7 @@
                                              keys-not-found
                                              nullify-empty-string-arguments parse-fdecl]]
             [gosura.helpers.superlifter :refer [with-superlifter]]
-            [gosura.util :as util :refer [transform-keys->camelCaseKeyword
-                                          transform-keys->kebab-case-keyword
-                                          update-resolver-result]]
+            [gosura.util :as util :refer [transform-keys->kebab-case-keyword]]
             [promesa.core :as prom]
             [superlifter.api :as superlifter-api]
             [taoensso.timbre :as log]))

--- a/src/gosura/util.clj
+++ b/src/gosura/util.clj
@@ -1,6 +1,7 @@
 (ns gosura.util
   (:require [camel-snake-kebab.core :as csk]
             [camel-snake-kebab.extras :as cske]
+            [gosura.helpers.case-format :as cf]
             [clojure.string :refer [ends-with?]]
             [com.walmartlabs.lacinia.resolve :refer [is-resolver-result?]]
             [com.walmartlabs.lacinia.select-utils :refer [is-wrapped-value?]]

--- a/test/gosura/core_test.clj
+++ b/test/gosura/core_test.clj
@@ -24,22 +24,22 @@
                             :resolvers {:resolve-connection {:table-fetcher 'gosura.core-test/fetch}}})
       (let [resolved (eval `(gosura.test-namespace0/resolve-connection nil {} {}))]
         (is (= resolved {:count 1
-                         :pageInfo {:hasPreviousPage false
-                                    :hasNextPage false
-                                    :startCursor "TlBZAHFpATFuAWkBMQ=="
-                                    :endCursor "TlBZAHFpATFuAWkBMQ=="}
+                         :page-info {:has-previous-page false
+                                     :has-next-page false
+                                     :start-cursor "TlBZAHFpATFuAWkBMQ=="
+                                     :end-cursor "TlBZAHFpATFuAWkBMQ=="}
                          :edges [{:cursor "TlBZAHFpATFuAWkBMQ=="
                                   :node {:id "dGVzdC10eXBlOjE="
                                          :content "test content"
-                                         :authorId "1"
-                                         :nodeType :test-type
-                                         :dbId "1"}}]}))))
+                                         :author-id "1"
+                                         :node-type :test-type
+                                         :db-id "1"}}]}))))
     (testing "edn schema에 맞지 않는 경우는 제대로 resolvers를 생성하지 못한다"
       (let [bad-data (set/rename-keys normal-data {:target-ns :target-typo-ns})]
         (is (thrown-with-msg? clojure.lang.ExceptionInfo #"resolvers 생성시 스키마가 맞지 않습니다" (gosura/generate-one bad-data))))))
   #_(testing "settings in auth? 가 잘 동작한다")
   #_(testing "settings in kebab-case? 가 잘 동작한다")
-  (testing "resolvers.settings in return-camel-case? false 가 잘 동작한다"
+  #_(testing "resolvers.settings in return-camel-case? false 가 잘 동작한다"
     (gosura/generate-one {:target-ns 'gosura.test-namespace1
                           :node-type :test-type
                           :db-key    :db
@@ -58,7 +58,7 @@
                                        :author-id "1"
                                        :node-type :test-type
                                        :db-id "1"}}]}))))
-  (testing "settings in return-camel-case? false 가 잘 동작한다"
+  #_(testing "settings in return-camel-case? false 가 잘 동작한다"
     (gosura/generate-one {:target-ns 'gosura.test-namespace2
                           :node-type :test-type
                           :db-key    :db
@@ -77,7 +77,7 @@
                                        :author-id "1"
                                        :node-type :test-type
                                        :db-id "1"}}]}))))
-  (testing "root in return-camel-case? false 가 잘 동작한다"
+  #_(testing "root in return-camel-case? false 가 잘 동작한다"
     (gosura/generate-one {:target-ns 'gosura.test-namespace3
                           :node-type :test-type
                           :db-key    :db
@@ -95,7 +95,7 @@
                                        :author-id "1"
                                        :node-type :test-type
                                        :db-id "1"}}]}))))
-  (testing "resolvers in return-camel-case? false 가 잘 동작한다"
+  #_(testing "resolvers in return-camel-case? false 가 잘 동작한다"
     (gosura/generate-one {:target-ns 'gosura.test-namespace4
                           :node-type :test-type
                           :db-key    :db
@@ -113,7 +113,7 @@
                                        :author-id "1"
                                        :node-type :test-type
                                        :db-id "1"}}]}))))
-  (testing "resolvers in return-camel-case? false override 가 잘 동작한다"
+  #_(testing "resolvers in return-camel-case? false override 가 잘 동작한다"
     (gosura/generate-one {:target-ns 'gosura.test-namespace5
                           :node-type :test-type
                           :db-key    :db
@@ -132,7 +132,7 @@
                                        :author-id "1"
                                        :node-type :test-type
                                        :db-id "1"}}]}))))
-  (testing "resolvers.settings in settings.return-camel-case? false override 가 잘 동작한다"
+  #_(testing "resolvers.settings in settings.return-camel-case? false override 가 잘 동작한다"
     (gosura/generate-one {:target-ns 'gosura.test-namespace6
                           :node-type :test-type
                           :db-key    :db

--- a/test/gosura/helpers/resolver_test.clj
+++ b/test/gosura/helpers/resolver_test.clj
@@ -130,7 +130,7 @@
           ctx          {:identity {:id "1"}}
           arg          {:intArg 1
                         :strArg "str"}
-          parent       {:myCol 1}
+          parent       {:my-col 1}
           empty-parent {}
           ok-result    (test-resolver-2 ctx arg parent)
           fail-result  (test-resolver-2 ctx arg empty-parent)]

--- a/test/gosura/helpers/resolver_test.clj
+++ b/test/gosura/helpers/resolver_test.clj
@@ -98,7 +98,7 @@
           result (test-resolver ctx arg parent)]
       (is (= (-> result
                  :arg
-                 :userId) "1"))))
+                 :user-id) "1"))))
   (testing "arg/parent가 default True로 kebab-case 설정이 잘 동작한다"
     (let [ctx    {:identity {:id "1"}}
           arg    {:intArg 1
@@ -108,7 +108,7 @@
       (is (= @arg-in-resolver {:int-arg 1
                                :str-arg "str"
                                :user-id "1"}))))
-  (testing "return value return-camel-case? 설정이 잘 동작한다"
+  #_(testing "return value return-camel-case? 설정이 잘 동작한다"
     (let [ctx    {:identity {:id "1"}}
           arg    {:intArg 1
                   :strArg "str"}
@@ -135,10 +135,10 @@
           ok-result    (test-resolver-2 ctx arg parent)
           fail-result  (test-resolver-2 ctx arg empty-parent)]
       (is (= ok-result {:ctx    {:identity {:id "1"}}
-                        :arg    {:intArg 1
-                                 :strArg "str"
-                                 :userId "1"}
-                        :parent {:myCol 1}}))
+                        :arg    {:int-arg 1
+                                 :str-arg "str"
+                                 :user-id "1"}
+                        :parent {:my-col 1}}))
       (is (= (-> fail-result
                  :resolved-value
                  :data
@@ -160,10 +160,10 @@
           result (test-resolver-3 ctx arg parent)]
       (is (= result {:ctx    {:identity {:id "1"
                                          :cc "KR"}}
-                     :arg    {:intArg      1
-                              :strArg      "str"
-                              :userId      "1"
-                              :countryCode "KR"}
+                     :arg    {:int-arg      1
+                              :str-arg      "str"
+                              :user-id      "1"
+                              :country-code "KR"}
                      :parent {}}))))
   (testing "auth 설정이 false를 반환해도 잘 동작한다"
     (let [_      (gosura-resolver2/defresolver test-resolver-4
@@ -204,7 +204,7 @@
           parent {}
           result (test-resolver-6 ctx arg parent)]
       (is (= (-> result
-                 :arg) {:testCol "1"}))))
+                 :arg) {:test-col "1"}))))
   (testing "잘못된 형식의 id가 입력되었을 때 decode-ids-by-keys가 nil을 넘겨준다"
     (let [_      (gosura-resolver2/defresolver test-resolver-7
                    {:decode-ids-by-keys [:test-col]}
@@ -217,7 +217,7 @@
           parent {}
           result (test-resolver-7 ctx arg parent)]
       (is (= (-> result
-                 :arg) {:testCol nil}))))
+                 :arg) {:test-col nil}))))
   (testing "에러가 던져졌을 때 GraphQL errors를 반환한다"
     (with-redefs [taoensso.timbre/-log! (fn [& args])]
       (let [_            (gosura-resolver2/defresolver test-resolver-8


### PR DESCRIPTION
> * `camel-snake-kebab` 케이스 변환은 매우 빈번하게 호출되며, APM에서 확인했을 때 CPU 사용률 비중 높음
> * `UserPostsFeedQuery` 쿼리 기준 case 변환이 1070회 호출, 이는 필드 resolver 들에 대해 case 변환이 중복으로 일어나고 있기 때문.
> * 케이스 변환을 최소화 하기 위해 [graphql 인자와 필드 케이싱 효율화 #2384](https://github.com/green-labs/farmmorning-clj/issues/2384) 를 적용했으나 아래의 문제가 있음.
> 
> 1. 하위 호환성 유지를 위해 `return-camel-case?` 의 기본설정은 여전히 true이고,  false 사용을 각 개발자에게 맡김.
> 2. 절대 다수의 resolver에서 여전히 비효율적인 형변환이 실행되고 있음.
> 
> 이를 해결하기 위해 다음을 실시할 예정입니다.
> 
> * `return-camel-case?` 및 `parent`의 `kebab-case?` 설정을 처리하는 로직을 defresolver, gosura, resolver-helper에서 없앤다. (있던 없던 상관없는 옵셔널 필드로 만듦)
> * default-field-resolver 에서 kebab, camel, + 예외(guava를 통해 kebab-case를 처리했을 때) 경우를 핸들링 할 수 있도록 한다.
> * default-field-resolver 에 대한 테스트를 추가하고, regression 테스트를 진행한다.
> 
> 이렇게 되면 csk 라이브러리가 호출되는 횟수를 실질적으로 ~10^3 에서 ~10^1 로 줄일 수 있을것으로 기대.

https://github.com/green-labs/farmmorning-clj/issues/2725 와 관련하여 `return-camel-case?` 및 `parent kebab-case?` 케이스 변환을 제거합니다.